### PR TITLE
Adding MCProduction enum to SusyDefs.

### DIFF
--- a/SusyNtuple/SusyDefs.h
+++ b/SusyNtuple/SusyDefs.h
@@ -75,6 +75,17 @@ typedef std::map<SumwMapKey, float> SumwMap;
 //-----------------------------------------------------------------------------------
 // Global enums
 //-----------------------------------------------------------------------------------
+
+// MC production campaign
+enum MCProduction
+{
+  MCProd_Unknown = 0,
+  MCProd_MC12a,
+  MCProd_MC12b,
+  MCProd_N
+};
+
+// Data stream
 enum DataStream
 {
   Stream_Unknown = 0,


### PR DESCRIPTION
This enum will allow to specify which MC production campaign a sample was made in.
This is important when initializing SUSYTools, because some settings (such as JES)
actually depend on the production campaign.

I assume the need for this specification is _temporary_, as this is the first
time people are using a mix of two productions simultaneously.
