### PR TITLE
Fixed warning when xsec not found in SUSYTools

### DIFF
--- a/Root/MCWeighter.cxx
+++ b/Root/MCWeighter.cxx
@@ -209,11 +209,13 @@ SUSY::CrossSectionDB::Process MCWeighter::getCrossSection(const Event* evt)
     else{
       // Hasn't been cached yet, load it from the DB
       CrossSectionDB::Process p = m_xsecDB.process(evt->mcChannel, proc);
+      if(p.xsect() < 0){
+        cerr << "MCWeighter::getCrossSection - WARNING - xsec not found in SUSYTools." << endl;
+      }
       m_xsecCache[k] = p;
       return p;
     }
   }
-  cerr << "MCWeighter::getCrossSection - WARNING - xsec not found in SUSYTools." << endl;
   return CrossSectionDB::Process();
 }
 


### PR DESCRIPTION
Fixed warning in MCWeighter when a cross section is not found in SUSYTools.

I figured out I hadn't implemented the warning properly after getting negative estimates because cross sections were not being found in SUSYTools. When an entry is not found in CrossSectionDB a default SUSY::CrossSectionDB::Process is returned, which has a cross section of -1. If the user doesn't catch these cases, the resulting estimates can be wrong.

I'm not totally sure a warning is appropriate, unless the user can live with some unavoidable cases. For example, in some of our C1N2 WZ samples, occasional events will have the final state variable missing (somehow not computed properly). Luckily only a small number of events seems to be affected, and the machinery in MCWeighter will work fine as long as the user rejects these events. So a user must have a requirement to reject an event if the returned _cross section_ is negative.

It might be safer to implement some kind of flag or return value which signals to the user that the xsec was not found. Or, an easy solution could be to set the cross section to 0 instead of -1, so that the event won't contribute to the final yield. I'm open to suggestions.
