### PR TITLE
ROOTCOREDIR -> ROOTCOREBIN

### DIFF
--- a/Root/DilTrigLogic.cxx
+++ b/Root/DilTrigLogic.cxx
@@ -21,7 +21,7 @@ DilTrigLogic::DilTrigLogic(string period, bool useReweightUtils) :
 
   // Create trigger reweight object
   m_triggerWeight = new triggerReweight2Lep();
-  string directory = "$ROOTCOREDIR/../DGTriggerReweight/data";
+  string directory = "$ROOTCOREBIN/data/DGTriggerReweight";
   m_triggerWeight->setDbg(1);
   if(useReweightUtils)
     m_triggerWeight->initialize(directory, period, true);//To turn on ReweightUtils 

--- a/Root/SleptonXsecReader.cxx
+++ b/Root/SleptonXsecReader.cxx
@@ -310,13 +310,13 @@ int SleptonXsecReader::populateDsidList(const char* filename)
   return knownDsids_.size() - initialKnownPoints;
 }
 //--------------------------------------
-bool SleptonXsecReader::getRootcoreDir(std::string &dir)
+bool SleptonXsecReader::getRootcoreBin(std::string &dir)
 {
-  char* rootcoredir = getenv("ROOTCOREDIR");
+  char* rootcoredir = getenv("ROOTCOREBIN");
   bool envvarDefined(rootcoredir!=0);
   if (!envvarDefined) {
     dir = "";
-    cout<<"SleptonXsecReader::getRootcoreDir: ROOTCOREDIR not defined"<<endl;
+    cout<<"SleptonXsecReader::getRootcoreBin: ROOTCOREBIN not defined"<<endl;
   } else {
     dir = rootcoredir;
   }
@@ -326,18 +326,18 @@ bool SleptonXsecReader::getRootcoreDir(std::string &dir)
 std::string SleptonXsecReader::getDefaultDsidFilename()
 {
   string rootcoredir, filename;
-  bool rcDirFound(SleptonXsecReader::getRootcoreDir(rootcoredir));
+  bool rcDirFound(SleptonXsecReader::getRootcoreBin(rootcoredir));
   if(rcDirFound) filename = rootcoredir + "/data/SusyNtuple/samplesList_pMSSM_DLiSlep.txt";
-  else           cout<<"invalid ROOTCOREDIR, cannot determine the default dsid file"<<endl;
+  else           cout<<"invalid ROOTCOREBIN, cannot determine the default dsid file"<<endl;
   return filename;
 }
 //--------------------------------------
 std::string SleptonXsecReader::getDefaultRootFilename()
 {
   string rootcoredir, filename;
-  bool rcDirFound(SleptonXsecReader::getRootcoreDir(rootcoredir));
+  bool rcDirFound(SleptonXsecReader::getRootcoreBin(rootcoredir));
   if(rcDirFound) filename = rootcoredir + "/data/SusyNtuple/DLiSlep_SignalUncertainties_All.root";
-  else           cout<<"invalid ROOTCOREDIR, cannot determine the default root file"<<endl;
+  else           cout<<"invalid ROOTCOREBIN, cannot determine the default root file"<<endl;
   return filename;
 }
 //--------------------------------------

--- a/Root/Susy3LepCutflow.cxx
+++ b/Root/Susy3LepCutflow.cxx
@@ -79,7 +79,7 @@ void Susy3LepCutflow::Begin(TTree* /*tree*/)
   m_trigObj->loadTriggerMaps();
 
   // MC Normalization - safe to initialize on data also
-  //string xsecDir = gSystem->ExpandPathName("$ROOTCOREDIR/data/SUSYTools/mc12_8TeV/");
+  //string xsecDir = gSystem->ExpandPathName("$ROOTCOREBIN/data/SUSYTools/mc12_8TeV/");
   //m_mcWeighter = new MCWeighter(m_tree, xsecDir);
 
   // Book histograms
@@ -94,7 +94,7 @@ void Susy3LepCutflow::Init(TTree* tree)
   SusyNtAna::Init(tree);
 
   // MC Normalization - safe to initialize on data also
-  string xsecDir = gSystem->ExpandPathName("$ROOTCOREDIR/data/SUSYTools/mc12_8TeV/");
+  string xsecDir = gSystem->ExpandPathName("$ROOTCOREBIN/data/SUSYTools/mc12_8TeV/");
   m_mcWeighter = new MCWeighter(m_tree, xsecDir);
 }
 

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -40,7 +40,7 @@ SusyNtTools::SusyNtTools() :
 void SusyNtTools::configureBTagTool(string OP, float opVal, bool isJVF)
 {
   // Initialize b-tag tool
-  string rootcoredir = getenv("ROOTCOREDIR");
+  string rootcoredir = getenv("ROOTCOREBIN");
   string calibration = rootcoredir + "/data/SusyNtuple/BTagCalibration_2013.env";
   string calibFolder = rootcoredir + "/data/SusyNtuple/";
   //string calibration = rootcoredir + "/data/SusyNtuple/BTagCalibration_2013.env";
@@ -125,7 +125,7 @@ SUSY::CrossSectionDB::Process SusyNtTools::getCrossSection(const Event* evt)
   // Use one DB and map for all instances of this class
   typedef pair<int, int> intpair;
   typedef map<intpair, CrossSectionDB::Process> XSecMap;
-  static string xsecDir = string(getenv("ROOTCOREDIR")) + "/data/SUSYTools/mc12_8TeV/";
+  static string xsecDir = string(getenv("ROOTCOREBIN")) + "/data/SUSYTools/mc12_8TeV/";
   static CrossSectionDB xsecDB(xsecDir);
   static XSecMap xsecCache;
   if(evt->isMC){

--- a/SusyNtuple/SleptonXsecReader.h
+++ b/SusyNtuple/SleptonXsecReader.h
@@ -112,7 +112,7 @@ class SleptonXsecReader {
   void printKnownPoints() const;
   static bool extractDsetidMslM1FromString(const char* dsetName, int &dsid, int &msl, int &m1, bool verbose=false);
   static std::string rmLeadingTrailingWhitespaces(const std::string &str);
-  static bool getRootcoreDir(std::string &dir); //!< safe getenv; return false if ROOTCOREDIR not defined
+  static bool getRootcoreBin(std::string &dir); //!< safe getenv; return false if ROOTCOREBIN not defined
   static std::string getDefaultDsidFilename(); //!< file with the dsid and mass values
   static std::string getDefaultRootFilename(); //!< file with the tree containing the xsec values 
   static std::string getDefaultTreeName();     //!< tree containing the xsec values


### PR DESCRIPTION
ROOTCOREBIN is the directory from which we pick up the /data/\* files.
ROOTCOREBIN and ROOTCOREDIR usually point to the same directory.
However, starting from RootCore-00-02-80 (pulled in by
SUSYTools-00-03-21, see [changeset578448](https://svnweb.cern.ch/trac/atlasoff/changeset/578448/PhysicsAnalysis/SUSYPhys/SUSYTools/trunk/python/install.py), note that 02-80>02-99),
we see that some of the grid jobs cannot access
files through ROOTCOREDIR.
