### PR TITLE
Dbg mcw susy

### DIFF
--- a/SusyNtuple/MCWeighter.h
+++ b/SusyNtuple/MCWeighter.h
@@ -49,6 +49,21 @@ class MCWeighter
       Sys_N
     };
 
+    /// Helper to keep track of events with  invalid process id
+    struct ProcessValidator {
+    ProcessValidator() : counts_total(0), counts_invalid(0), max_warnings(4), valid(false), last(0) {}
+      size_t counts_total;
+      size_t counts_invalid;
+      size_t max_warnings;
+      /// if necessary, convert our 'unknown' value (-1) to the SUSYTools 'unknown' value (0)
+      /**
+         Also flag as invalid the suspicious events (i.e. when proc==-1 and proc!=previous_proc)
+       */
+      ProcessValidator& validate(int &value);
+      bool valid; ///< status from the current call to validate()
+      int last; ///< procid from the last call to validate()
+      std::string summary() const;
+    };
     //
     // Initialization and configuration
     //
@@ -145,6 +160,7 @@ class MCWeighter
 
     std::string m_labelBinCounter; ///< label of the bin (from the SusyNt histos) used to determine sumw
     size_t m_warningCounter;
+    ProcessValidator m_procidValidator; ///< validate susy process id
 };
 
 

--- a/util/test_mcWeighter.cxx
+++ b/util/test_mcWeighter.cxx
@@ -56,6 +56,24 @@ int main(int argc, char **argv)
     mcw.dumpXsecCache();
     mcw.dumpXsecDb();
     //cout<<"xsec for 105200: "<<mcw.getXsecTimesEff()<<endl; // bummer! can only test with Susy::Event...to be modified.
+
+    MCWeighter::ProcessValidator validator;
+    int procID=137;
+    validator.validate(procID);
+    validator.validate(procID);
+    cout<<"validator.validate("<<procID<<").valid : "<<(validator.valid?"true":"false")<<", expect true"<<endl;
+    procID=-1;
+validator.validate(procID);
+    cout<<"validator.validate("<<procID<<").valid : "<<(validator.valid?"true":"false")<<", expect false"<<endl;
+    procID=137;
+validator.validate(procID);
+    procID=0;
+validator.validate(procID);
+    cout<<"validator.validate("<<procID<<").valid : "<<(validator.valid?"true":"false")<<", expect false"<<endl;
+
+
+
     return 0;
+
 }
 //----------------------------------------------------------


### PR DESCRIPTION
Debugging the susy dsid that Anyes reported as missing.
The sample-specific test might be dropped once we've sorted out what's going on, but the additional `MCWeighter::dump*` methods should be kept.
