### PR TITLE
add WhTruthExtractor::higgsEventParticleIndices

### DIFF
--- a/Root/WhTruthExtractor.cxx
+++ b/Root/WhTruthExtractor.cxx
@@ -167,3 +167,20 @@ WhTruthExtractor::vint_t WhTruthExtractor::ttbarMcAtNloParticles(const vint_t *p
   return particles;
 }
 //----------------------------------
+WhTruthExtractor::vint_t WhTruthExtractor::higgsEventParticleIndices(const vint_t* pdg,
+                                                                     const vvint_t *childIndex,
+                                                                     const vvint_t *parentIndex)
+{
+    vint_t indices;
+    update(pdg, childIndex, parentIndex);
+    bool interesting_H_was_found = (interestingHiggs_ >=0);
+    if(interesting_H_was_found){
+        const int hIdx = hIndices_[interestingHiggs_];
+        const vint_t &chIdxs  = childIndex ->at(hIdx);
+        indices.push_back(hIdx);
+        indices.insert(indices.end(), chIdxs.begin(), chIdxs.end());
+        // note to self: the h parent is usually another h; no need to store parents
+    }
+    return indices;
+}
+//----------------------------------

--- a/SusyNtuple/WhTruthExtractor.h
+++ b/SusyNtuple/WhTruthExtractor.h
@@ -36,6 +36,11 @@ class WhTruthExtractor {
    */
   static vint_t ttbarMcAtNloParticles(const vint_t *pdgs,
                                       const vvint_t *childrenIndices);
+  /// indices of the relevant particle for a higgs event (H, its parents, its children)
+  /**
+     Internally calls @update()
+  */
+ vint_t higgsEventParticleIndices(const vint_t* pdg, const vvint_t *childIndex, const vvint_t *parentIndex);
  public:
   bool verbose_;
   const vint_t pdgsPbAb_;


### PR DESCRIPTION
Needed for H pt reweighting for HLFV.
Goes with SusyCommon-00-01-09
