### PR TITLE
Refactor implementation of object selectors

### DIFF
--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -1,359 +1,194 @@
 #include "SusyNtuple/ElectronSelector.h"
-#include "SusyNtuple/MuonSelector.h"
-#include "SusyNtuple/SusyNt.h"
+#include "SusyNtuple/Electron.h"
 
 #include <algorithm>
 #include <cassert>
 #include <iostream>
+#include <cmath> // abs
 
-using Susy::ElectronSelector;
-using Susy::Electron;
 using Susy::NtSys::SusyNtSys;
 using std::cout;
 using std::endl;
 using std::string;
 
 namespace Susy {
-// -------------------------------------------------------------------------------------------- //
-// Constructor
-// -------------------------------------------------------------------------------------------- //
+
+//----------------------------------------------------------
+ElectronSelector* ElectronSelector::build(const AnalysisType &a, bool verbose)
+{
+    ElectronSelector* s = nullptr;
+    switch(a) {
+    case AnalysisType::Ana_2Lep:
+        s = new ElectronSelector_2Lep();
+        s->setSignalId(ElectronId::TightLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_3Lep:
+        s = new ElectronSelector_3Lep();
+        s->setSignalId(ElectronId::TightLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_2LepWH:
+        s = new ElectronSelector_2LepWH();
+        s->setSignalId(ElectronId::TightLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_SS3L:
+        s = new ElectronSelector_SS3L();
+        s->setSignalId(ElectronId::TightLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_Stop2L:
+        s = new ElectronSelector_Stop2L();
+        s->setSignalId(ElectronId::MediumLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
+    default:
+        cout<<"ElectronSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
+            <<" returning vanilla ElectronSelector"<<endl;
+        s = new ElectronSelector();
+    }
+    return s;
+}
+//---------------------------------------------------------
 ElectronSelector::ElectronSelector() :
-    //////////////////////////
-    // default selection
-    //////////////////////////
-    EL_MIN_PT_BASELINE(10.0),
-    EL_MIN_PT_SIGNAL(10.0),
-    EL_MAX_ETA_BASELINE(2.47),
-    EL_MAX_ETA_SIGNAL(2.47),
-    EL_ISO_PT_THRS(60.0),
-    EL_PTCONE30_PT_CUT(0.16),
-    EL_TOPOCONE30_PT_CUT(0.18),
-    EL_MAX_D0SIG(5.0),
-    EL_MAX_Z0_SINTHETA(0.4),
-    EL_MIN_CRACK_ETA(1.37),
-    EL_MAX_CRACK_ETA(1.52),
-    //////////////////////////
-    m_systematic(NtSys::NOM),
-    m_analysis(AnalysisType::kUnknown),
-    m_vetoCrackRegion(false),
-    m_doIPCut(false),
-    m_eleBaseId(ElectronId::ElectronIdInvalid),
-    m_eleId(ElectronId::ElectronIdInvalid),   
-    m_sigIso(Isolation::IsolationInvalid),
-    m_2lep(false),
-    m_3lep(false),
-    m_2lepWH(false),
-    m_SS3L(false),
-    m_stop2l(false),
+    m_signalId(ElectronId::ElectronIdInvalid),
+    m_signalIsolation(Isolation::IsolationInvalid),
     m_verbose(false)
 {
 }
-// -------------------------------------------------------------------------------------------- //
-ElectronSelector& ElectronSelector::setAnalysis(const AnalysisType &a)
+//---------------------------------------------------------
+bool ElectronSelector::isBaselineElectron(const Electron* el)
 {
-
-    //////////////////////////////////////
-    // Set analysis-specific cuts
-    //////////////////////////////////////
-
-    //////////////////////////////////////
-    // 2L-ANALYSIS
-    //////////////////////////////////////
-    if( a == AnalysisType::Ana_2Lep ) {
-        m_2lep = true;
-
-        // baseline
-        m_eleBaseId = ElectronId::LooseLH;
-        // signal
-        m_eleId  = ElectronId::TightLH;
-        m_sigIso = Isolation::GradientLoose;
-
-        m_doIPCut           = true;
-    } 
-    //////////////////////////////////////
-    // 3L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_3Lep ) {
-        m_3lep = true;
-
-        //baseline
-        m_eleBaseId = ElectronId::LooseLH;
-        // signal
-        m_eleId  = ElectronId::TightLH;
-        m_sigIso = Isolation::GradientLoose;
-
-        m_doIPCut           = true;
-
+    bool pass = false;
+    if(el) {
+        pass = (el->looseLH && // good for all
+                el->Pt()  > 10.0 && // was EL_MIN_PT_BASELINE, good for all
+                std::abs(el->clusEta) < 2.47 ); // was EL_MAX_ETA_BASELINE, good for all
     }
-    //////////////////////////////////////
-    // WH-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_2LepWH ) {
-        m_2lepWH = true;
-
-        // baseline
-        m_eleBaseId = ElectronId::LooseLH;
-        // signal
-        m_eleId  = ElectronId::TightLH;
-        m_sigIso = Isolation::GradientLoose;
-
-        m_doIPCut           = true;
-
-        // cuts
-        EL_PTCONE30_PT_CUT              = 0.07;
-        EL_TOPOCONE30_PT_CUT            = 0.13;
-        EL_MAX_D0SIG                    = 3.0; 
-
-    }
-    ////////////////////////////////////
-    // SS3L-ANALYSIS
-    // values from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
-    ////////////////////////////////////
-    else if( a == AnalysisType::Ana_SS3L ) {
-        m_SS3L = true;
-        // baseline
-        m_eleBaseId         = ElectronId::LooseLH;
-        EL_MIN_PT_BASELINE  = 10.0;
-        EL_MAX_ETA_BASELINE = 2.47;
-        EL_MAX_D0SIG        = 5.0;
-        m_vetoCrackRegion   = true;
-        EL_MIN_CRACK_ETA    = 1.37;
-        EL_MAX_CRACK_ETA    = 1.52;
-        // signal
-        m_eleId             = ElectronId::TightLH;
-        EL_MAX_ETA_SIGNAL   = 2.0;
-        m_sigIso            = Isolation::GradientLoose;
-        EL_MAX_Z0_SINTHETA  = 0.5;
-        m_doIPCut           = true; // DG-2015-09-01 not sure about this
-    }
-    //////////////////////////////////////
-    // Stop2L-Analysis
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_Stop2L ) {
-        m_stop2l = true;
-
-        //baseline
-        m_eleBaseId         = ElectronId::LooseLH;
-        //signal
-        m_eleId             = ElectronId::MediumLH;
-        m_sigIso            = Isolation::GradientLoose;
-        m_doIPCut           = true;
-
-        //cuts
-        EL_MAX_Z0_SINTHETA  = 0.5;
-    }
-    //////////////////////////////////////
-    // Didn't set AnalysisType
-    //////////////////////////////////////
-    else if( a == AnalysisType::kUnknown ) {
-        string error = "ElectronSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for ElectronSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for ElectronSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    //////////////////////////////////////
-    // Gone fishin'
-    //////////////////////////////////////
-    else {
-        string error = "ElectronSelector::setAnalysis error: ";
-        cout << error << "ElectronSelector is not configured for the AnalysisType (" << AnalysisType2str(a) << ")  provided in " << endl;
-        cout << error << "'setAnalysis'! Be sure that your AnalysisType is provided for in SusyNtuple/AnalysisType.h" << endl;
-        cout << error << "and that you provide the necessary requirements for your analysis in 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    m_analysis = a;
-
-    // check that the ele Id's have been set
-    if(m_eleId == ElectronId::ElectronIdInvalid || m_eleBaseId == ElectronId::ElectronIdInvalid) {
-        string error = "ElectronSelector::setAnalysis error: "; 
-        cout << error << "Baseline and/or signal electron ID requirements are not set." << endl;
-        cout << error << "Baseline ID = " << ElectronId2str(m_eleBaseId) 
-                                                       << " Signal ID = " << ElectronId2str(m_eleId) << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    // check that the ele signal isolation has been set
-    if(m_sigIso == Isolation::IsolationInvalid) {
-        string error = "ElectronSelector::setAnalysis error: ";
-        cout << error << "Signal electron isolation requirement is not set." << endl;
-        cout << error << "Electron isolation = " << Isolation2str(m_sigIso) << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    if (m_verbose)
-        cout << "ElectronSelector    Configured electron selection for AnalysisType " << AnalysisType2str(m_analysis) << endl;
-    
-    return *this;
+    return pass;
 }
-// ---------------------------------------------------------
-ElectronSelector& ElectronSelector::setSystematic(const NtSys::SusyNtSys &s)
+//----------------------------------------------------------
+bool ElectronSelector::isSignalElectron(const Electron* el)
 {
-    m_systematic = s;
-    return *this;
-}
-// ---------------------------------------------------------
-bool ElectronSelector::isBaselineElectron(const Electron* ele)
-{
-    ElectronSelector::check();
-
-    /////////////////////////////
-    // Electron ID
-    /////////////////////////////
-    if(!elecPassID(ele, false)) return false;
-
-    //////////////////////////
-    // eta/pT
-    //////////////////////////
-    if(fabs(ele->clusEta) > EL_MAX_ETA_BASELINE) return false;
-    if(ele->Pt() < EL_MIN_PT_BASELINE) return false;
-       
-    //////////////////////////
-    // veto detector
-    //////////////////////////
-    if(m_vetoCrackRegion){
-        if(fabs(ele->clusEta)> EL_MIN_CRACK_ETA &&
-           fabs(ele->clusEta)< EL_MAX_CRACK_ETA) return false;
+    bool pass = false;
+    if(el) {
+        pass = (el->Pt() > 10.0 && // good for all
+                std::abs(el->Eta()) < 2.47 && // was EL_MAX_ETA_SIGNAL
+                el->tightLH && // good for all run1 ana
+                passIpCut(*el) && // 5.0 0.4 good for 2l 3l
+                el->isoGradientLoose); // good for all run1
     }
-    
-    if (m_doIPCut && m_SS3L) {
-        if(fabs(ele->d0sigBSCorr)  >= EL_MAX_D0SIG)   return false;
-    }
-    
-    return true;
-
+    return pass;
 }
-// ---------------------------------------------------------
-bool ElectronSelector::isSignalElectron(const Electron* ele)
-{
-    ElectronSelector::check();
-
-    /////////////////////////////
-    // Electron ID
-    /////////////////////////////
-    if(!elecPassID(ele, true)) return false;
-     
-    /////////////////////////////
-    // Eta
-    /////////////////////////////
-    if(fabs(ele->Eta()) > EL_MAX_ETA_SIGNAL ) return false;
-    
-
-    /////////////////////////////
-    // Impact parameter
-    /////////////////////////////
-    if (m_doIPCut) {
-        if(fabs(ele->d0sigBSCorr)      >= EL_MAX_D0SIG)   return false;
-        if(fabs(ele->z0SinTheta()) >= EL_MAX_Z0_SINTHETA) return false;
-    }
-    
-    /////////////////////////////
-    // isolation now uses
-    // isolation tool
-    /////////////////////////////
-    if(!elecPassIsolation(ele)) return false;
-
-    /////////////////////////////
-    // ele pt
-    /////////////////////////////
-    if(ele->Pt() < EL_MIN_PT_SIGNAL) return false;
-    
-    return true;
-}
-/* --------------------------------------------------------------------------------------------- */ 
-bool ElectronSelector::isSemiSignalElectron(const Electron* ele)
-{
-    ElectronSelector::check();
-
-    /////////////////////////////
-    // Electron ID
-    /////////////////////////////
-    if(!elecPassID(ele, true)) return false;
-
-    /////////////////////////////
-    // Impact parameter
-    /////////////////////////////
-    if(m_doIPCut) {
-        if(fabs(ele->d0sigBSCorr) >= EL_MAX_D0SIG) return false;
-        if(fabs(ele->z0SinTheta()) >= EL_MAX_Z0_SINTHETA) return false;
-    }
-    return true;
-}
-/* --------------------------------------------------------------------------------------------- */ 
-bool ElectronSelector::elecPassID(const Electron* electron, bool signalQuality)
-{
-    ElectronId id = signalQuality ? m_eleId : m_eleBaseId;
-
-    if     (id == ElectronId::MediumLH)        return electron->mediumLH;
-    else if(id == ElectronId::LooseLH)         return electron->looseLH;
-    else if(id == ElectronId::TightLH)         return electron->tightLH;
-    else if(id == ElectronId::MediumLH_nod0)   return electron->mediumLH_nod0;
-    else if(id == ElectronId::TightLH_nod0)    return electron->tightLH_nod0;
-    else {
-        cout << "ElectronSelector::elecPassID() error: (signal) ele ID requirement not set for analysis!" << endl;
-        cout << "        Will set to TightLH." << endl;
-        return electron->tightLH;
-    }
-    
-    return false;
-
-}
-/* --------------------------------------------------------------------------------------------- */ 
-bool ElectronSelector::elecPassIsolation(const Electron* ele)
-{
-    if     (m_sigIso == Isolation::GradientLoose) return ele->isoGradientLoose;
-    else if(m_sigIso == Isolation::Gradient)    return ele->isoGradient;
-    else if(m_sigIso == Isolation::LooseTrackOnly) return ele->isoLooseTrackOnly;
-    else if(m_sigIso == Isolation::Loose) return ele->isoLoose;
-    else if(m_sigIso == Isolation::Tight) return ele->isoTight; 
-    else {
-        cout << "ElectronSelector::elecPassIsolation error: isolation requirement for electrons not set to signal-level isolation (Loose or Tight)" << endl;
-        cout << "ElectronSelector::elecPassIsolation error: >>> Exiting." << endl;
-        exit(1);
-    } 
-}
-/* --------------------------------------------------------------------------------------------- */
+//----------------------------------------------------------
 float ElectronSelector::effSF(const Electron& ele)
 {
-    ElectronSelector::check();
     // return the EffSF for the corresponding (signal) EL ID WP
-    return ele.eleEffSF[m_eleId]; 
+    return ele.eleEffSF[m_signalId];
 }
-/* --------------------------------------------------------------------------------------------- */
+//----------------------------------------------------------
 float ElectronSelector::errEffSF(const Electron& ele, const SusyNtSys sys)
 {
-    ElectronSelector::check();
     // return the error on the electron SF associated with systematic sys
     float err = 0.0;
     if(sys == NtSys::EL_EFF_ID_TotalCorrUncertainty_UP) {
-        err = ele.errEffSF_id_corr_up[m_eleId];
+        err = ele.errEffSF_id_corr_up[m_signalId];
     }
     else if(sys == NtSys::EL_EFF_ID_TotalCorrUncertainty_DN) {
-        err = ele.errEffSF_id_corr_dn[m_eleId];
+        err = ele.errEffSF_id_corr_dn[m_signalId];
     }
     else if(sys == NtSys::EL_EFF_Reco_TotalCorrUncertainty_UP) {
-        err = ele.errEffSF_reco_corr_up[m_eleId];
-    } 
+        err = ele.errEffSF_reco_corr_up[m_signalId];
+    }
     else if(sys == NtSys::EL_EFF_Reco_TotalCorrUncertainty_DN) {
-        err = ele.errEffSF_reco_corr_dn[m_eleId];
+        err = ele.errEffSF_reco_corr_dn[m_signalId];
     }
     return err;
 }
-/* --------------------------------------------------------------------------------------------- */
-void ElectronSelector::check()
+//----------------------------------------------------------
+bool ElectronSelector::passIpCut(const Electron &el)
 {
-    if(m_analysis == AnalysisType::kUnknown) {
-        string error = "ElectronSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for ElectronSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for ElectronSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    return;
+    return (std::abs(el.d0sigBSCorr)  < 5.0 &&
+            std::abs(el.z0SinTheta()) < 0.4 );
 }
-/* --------------------------------------------------------------------------------------------- */
+//----------------------------------------------------------
+bool ElectronSelector::outsideCrackRegion(const Electron &el)
+{
+    return (std::abs(el.clusEta) < 1.37 ||
+            std::abs(el.clusEta) > 1.52 );
+}
 
-}; // namespace Susy
+//----------------------------------------------------------
+// begin ElectronSelector_2Lep
+//----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin ElectronSelector_3Lep
+//----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin ElectronSelector_2LepWH
+//----------------------------------------------------------
+bool ElectronSelector_2LepWH::passIpCut(const Electron &el)
+{
+    return (std::abs(el.d0sigBSCorr)  < 3.0 && // tighter than default
+            std::abs(el.z0SinTheta()) < 0.4 );
+
+}
+
+//----------------------------------------------------------
+// begin ElectronSelector_SS3L
+//----------------------------------------------------------
+bool ElectronSelector_SS3L::isBaselineElectron(const Electron* el)
+{
+    bool pass = false;
+    if(el) {
+        pass = (el->looseLH &&
+                el->Pt()             > 10.0  &&
+                std::abs(el->clusEta)    <  2.47 &&
+                abs(el->d0sigBSCorr) <  5.0  &&
+                outsideCrackRegion(*el));
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool ElectronSelector_SS3L::isSignalElectron(const Electron* el)
+{
+    bool pass = false;
+    if(el) {
+        bool isIsolated = ((el->ptvarcone20/el->Pt()  < 0.06) &&
+                           (el->etconetopo20/el->Pt() < 0.06) );
+        pass = (isBaselineElectron(el) &&
+                isIsolated &&
+                el->tightLH &&
+                std::abs(el->trackEta)     <  2.0 &&
+                std::abs(el->z0SinTheta()) <  0.5 );
+    }
+    return pass;
+}
+
+//----------------------------------------------------------
+// begin ElectronSelector_Stop2L
+// TODO Danny please check values
+//----------------------------------------------------------
+bool ElectronSelector_Stop2L::passIpCut(const Electron &el)
+{
+    return (std::abs(el.d0sigBSCorr)  < 3.0 &&
+            std::abs(el.z0SinTheta()) < 0.5 );
+
+}
+//----------------------------------------------------------
+bool ElectronSelector_Stop2L::isSignalElectron(const Electron* el)
+{
+    bool pass = false;
+    if(el) {
+        pass = (isBaselineElectron(el) &&
+                el->mediumLH &&
+                el->isoGradientLoose &&
+                passIpCut(*el));
+    }
+    return pass;
+}
+//----------------------------------------------------------
+} // namespace Susy

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -58,7 +58,7 @@ ElectronSelector::ElectronSelector() :
 {
 }
 //---------------------------------------------------------
-bool ElectronSelector::isBaselineElectron(const Electron* el)
+bool ElectronSelector::isBaseline(const Electron* el)
 {
     bool pass = false;
     if(el) {
@@ -69,7 +69,7 @@ bool ElectronSelector::isBaselineElectron(const Electron* el)
     return pass;
 }
 //----------------------------------------------------------
-bool ElectronSelector::isSignalElectron(const Electron* el)
+bool ElectronSelector::isSignal(const Electron* el)
 {
     bool pass = false;
     if(el) {
@@ -140,7 +140,7 @@ bool ElectronSelector_2LepWH::passIpCut(const Electron &el)
 //----------------------------------------------------------
 // begin ElectronSelector_SS3L
 //----------------------------------------------------------
-bool ElectronSelector_SS3L::isBaselineElectron(const Electron* el)
+bool ElectronSelector_SS3L::isBaseline(const Electron* el)
 {
     bool pass = false;
     if(el) {
@@ -153,13 +153,13 @@ bool ElectronSelector_SS3L::isBaselineElectron(const Electron* el)
     return pass;
 }
 //----------------------------------------------------------
-bool ElectronSelector_SS3L::isSignalElectron(const Electron* el)
+bool ElectronSelector_SS3L::isSignal(const Electron* el)
 {
     bool pass = false;
     if(el) {
         bool isIsolated = ((el->ptvarcone20/el->Pt()  < 0.06) &&
                            (el->etconetopo20/el->Pt() < 0.06) );
-        pass = (isBaselineElectron(el) &&
+        pass = (isBaseline(el) &&
                 isIsolated &&
                 el->tightLH &&
                 std::abs(el->trackEta)     <  2.0 &&
@@ -179,11 +179,11 @@ bool ElectronSelector_Stop2L::passIpCut(const Electron &el)
 
 }
 //----------------------------------------------------------
-bool ElectronSelector_Stop2L::isSignalElectron(const Electron* el)
+bool ElectronSelector_Stop2L::isSignal(const Electron* el)
 {
     bool pass = false;
     if(el) {
-        pass = (isBaselineElectron(el) &&
+        pass = (isBaseline(el) &&
                 el->mediumLH &&
                 el->isoGradientLoose &&
                 passIpCut(*el));

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -170,7 +170,6 @@ bool ElectronSelector_SS3L::isSignal(const Electron* el)
 
 //----------------------------------------------------------
 // begin ElectronSelector_Stop2L
-// TODO Danny please check values
 //----------------------------------------------------------
 bool ElectronSelector_Stop2L::passIpCut(const Electron &el)
 {

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -22,7 +22,7 @@ JetSelector* JetSelector::build(const AnalysisType &a, bool verbose)
     case AnalysisType::Ana_2Lep   : selector = new JetSelector_2Lep(); break;
     case AnalysisType::Ana_3Lep   : selector = new JetSelector_3Lep(); break;
     case AnalysisType::Ana_2LepWH : selector = new JetSelector_2LepWH(); break;
-    case AnalysisType::Ana_SS3L   : selector = new JetSelector_ss3l(); break;
+    case AnalysisType::Ana_SS3L   : selector = new JetSelector_SS3L(); break;
     case AnalysisType::Ana_Stop2L : selector = new JetSelector_Stop2L(); break;
     default:
         cout<<"JetSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
@@ -146,9 +146,9 @@ size_t JetSelector::count_F_jets(const JetVector &jets)
 //----------------------------------------------------------
 
 //----------------------------------------------------------
-// begin JetSelector_ss3l
+// begin JetSelector_SS3L
 //----------------------------------------------------------
-bool JetSelector_ss3l::isBaselineJet(const Jet* jet)
+bool JetSelector_SS3L::isBaselineJet(const Jet* jet)
 {
     bool pass = false;
     if(jet){
@@ -158,7 +158,7 @@ bool JetSelector_ss3l::isBaselineJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_ss3l::isSignalJet(const Jet* jet)
+bool JetSelector_SS3L::isSignalJet(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
@@ -170,7 +170,7 @@ bool JetSelector_ss3l::isSignalJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_ss3l::isBJet(const Jet* jet)
+bool JetSelector_SS3L::isBJet(const Jet* jet)
 {
     bool pass = false;
     if(jet) {

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -1,13 +1,11 @@
 #include "SusyNtuple/JetSelector.h"
-#include "SusyNtuple/SusyNt.h"
+#include "SusyNtuple/Jet.h"
 
 #include <algorithm>
 #include <cassert>
 #include <iostream>
 #include <type_traits> // underlying_type
 
-using Susy::JetSelector;
-using Susy::Jet;
 using Susy::NtSys::SusyNtSys;
 using std::cout;
 using std::endl;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -60,7 +60,7 @@ bool JetSelector::isBJet(const Jet* jet)
 {
     return ((jet->Pt()        > 20.0   ) &&
             (fabs(jet->Eta()) <  2.5   ) &&
-            (jet->mv2c20      > -0.4434) && // 77% eff
+            (jet->mv2c20      > mv2c20_77efficiency()) &&
             (passJvt(jet)));
 }
 //----------------------------------------------------------
@@ -177,7 +177,7 @@ bool JetSelector_ss3l::isBJet(const Jet* jet)
         pass = (jet->Pt()        > 20.0    &&
                 fabs(jet->Eta()) <  2.4    &&
                 passJvt(jet)               &&
-                jet->mv2c20      > -0.0436 ); // 70% eff
+                jet->mv2c20      > mv2c20_70efficiency());
     }
     return pass;
 }

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -14,138 +14,29 @@ using std::endl;
 using std::string;
 
 namespace Susy {
-// ---------------------------------------------------------------------------- //
-//   Constructor
-// ---------------------------------------------------------------------------- //
+//----------------------------------------------------------
+JetSelector* JetSelector::build(const AnalysisType &a, bool verbose)
+{
+    JetSelector *selector;
+    switch(a) {
+    case AnalysisType::Ana_2Lep   : selector = new JetSelector_2Lep(); break;
+    case AnalysisType::Ana_3Lep   : selector = new JetSelector_3Lep(); break;
+    case AnalysisType::Ana_2LepWH : selector = new JetSelector_2LepWH(); break;
+    case AnalysisType::Ana_SS3L   : selector = new JetSelector_ss3l(); break;
+    case AnalysisType::Ana_Stop2L : selector = new JetSelector_Stop2L(); break;
+    default:
+        cout<<"JetSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
+            <<" returning vanilla JetSelector"<<endl;
+        selector = new JetSelector();
+    }
+    return selector;
+}
+//----------------------------------------------------------
 JetSelector::JetSelector() :
-    // benchmark MV2c20 tagger cuts: https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingBenchmarks#MV2c20_tagger_AntiKt4EMTopoJets
-
-    ///////////////////////////////
-    // default selection
-    ///////////////////////////////
-    JET_MIN_PT_BASELINE(20.0), // GeV
-    JET_MIN_PT_SIGNAL(30.0), // GeV
-    JET_MIN_PT_L25(25.0), // GeV
-    JET_MIN_PT_L20(20.0), // GeV
-    JET_MIN_PT_B20(20.0), // GeV
-    JET_MIN_PT_F30(30.0), // GeV
-    JET_MAX_ETA(2.4),
-    JET_MAX_ETA_FORWARD(4.5),
-    JET_JVT_CUT(0.64),
-    JET_JVT_ETA_CUT(2.4),
-    JET_JVT_PT_CUT(50.0), // GeV
-    JET_MV2C20_85(-0.7887),
-    JET_MV2C20_80(-0.5911),
-    JET_MV2C20_77(-0.4434),
-    JET_MV2C20_70(-0.0436),
-    JET_MV2C20_60(0.4496),
-    JET_MV2C20_OR(JET_MV2C20_80),
-    ///////////////////////////////
     m_systematic(NtSys::NOM),
-    m_analysis(AnalysisType::kUnknown),
-    m_2lep(false),
-    m_3lep(false),
-    m_2lepWH(false),
-    m_SS3L(false),
-    m_stop2l(false),
     m_verbose(false)
 {
 }
-//----------------------------------------------------------
-JetSelector& JetSelector::setAnalysis(const AnalysisType &a)
-{
-
-    ////////////////////////////////////
-    // Set analysis-specific cuts
-    ////////////////////////////////////
-    
-    ////////////////////////////////////
-    // 2L-ANALYSIS
-    ////////////////////////////////////
-    if( a == AnalysisType::Ana_2Lep ) {
-        m_2lep = true;
-
-        // use defaults
-        JET_MIN_PT_SIGNAL = 20.;
-    }
-    ////////////////////////////////////
-    // 3L-ANALYSIS
-    ////////////////////////////////////
-    else if( a == AnalysisType::Ana_3Lep ) {
-        m_3lep = true;
-
-        // pt
-        JET_MIN_PT_SIGNAL   = 20.;
-    }
-    ////////////////////////////////////
-    // WH-ANALYSIS
-    ////////////////////////////////////
-    else if( a == AnalysisType::Ana_2LepWH ) {
-        m_2lepWH = true;
-
-        // use defaults
-    }
-    ////////////////////////////////////
-    // SS3L-ANALYSIS
-    // values from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
-    ////////////////////////////////////
-    else if( a == AnalysisType::Ana_SS3L ) {
-        m_SS3L = true;
-        JET_MIN_PT_BASELINE = 20.0;
-        JET_MIN_PT_SIGNAL   = 20.0;
-        JET_MAX_ETA         = 2.8;
-        // jvt
-        JET_JVT_CUT         = 0.64;
-        JET_JVT_ETA_CUT     = 2.4;
-        JET_JVT_PT_CUT      = 50.0;
-        // bjet
-        JET_MIN_PT_B20      = 20.0;
-        JET_MV2C20_80       = -0.5911;
-        JET_MV2C20_70       = -0.0436;
-        JET_MV2C20_OR       = JET_MV2C20_80;
-    }
-    ////////////////////////////////////
-    // Stop2L-ANALYSIS
-    ////////////////////////////////////
-    else if( a == AnalysisType::Ana_Stop2L ) {
-        m_stop2l = true;
-
-        //pt
-        JET_MIN_PT_SIGNAL = 20.;
-
-        //eta
-        JET_MAX_ETA = 2.8;
-    }
-    ////////////////////////////////////
-    // Didn't set AnalysisType
-    ////////////////////////////////////
-    else if( a == AnalysisType::kUnknown ) {
-        string error = "JetSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for JetSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for JetSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    ////////////////////////////////////
-    // Gone fishin'
-    ////////////////////////////////////
-    else {
-        string error = "JetSelector::setAnalysis error: ";
-        cout << error << "JetSelector is not configured for the AnalysisType (" << AnalysisType2str(a) << ") provided in" << endl;
-        cout << error << "'setAnalysis'! Be sure that your AnalysisType is provided for in SusyNtuple/AnalysisType.h" << endl;
-        cout << error << "and that you provide the necessary requirements for your analysis in 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    m_analysis = a;
-
-    if(m_verbose)
-        cout << "JetSelector    Configured jet selection for AnalysisType " << AnalysisType2str(m_analysis) << endl;
-
-    return *this;
-}
-
 //----------------------------------------------------------
 JetSelector& JetSelector::setSystematic(const NtSys::SusyNtSys &s)
 {
@@ -155,182 +46,177 @@ JetSelector& JetSelector::setSystematic(const NtSys::SusyNtSys &s)
 //----------------------------------------------------------
 bool JetSelector::isBaselineJet(const Jet* jet)
 {
-    if(m_2lep || m_2lepWH || m_3lep) {
-        return (jet->Pt() > JET_MIN_PT_BASELINE);
-    } else {
-        bool passEta = (fabs(jet->Eta()) < JET_MAX_ETA);
-        bool passPt  = (jet->Pt() > JET_MIN_PT_BASELINE);
-        return (passEta && passPt);
-    }
+    return (jet->Pt() > 20.0);
 }
 //----------------------------------------------------------
 bool JetSelector::isSignalJet(const Jet* jet)
 {
-    JetSelector::check();
-
-    bool pass = false;
-    if(jet) {
-        if(m_2lep || m_2lepWH) {
-            pass = (isCentralLightJet(jet) || isCentralBJet(jet) || isForwardJet(jet));
-        }
-        else if(m_3lep || m_SS3L) {
-            pass = ((jet->Pt() > JET_MIN_PT_SIGNAL)
-                     && (fabs(jet->Eta()) < JET_MAX_ETA)
-                     && jetPassesJvtRequirement(jet));
-        }
-    } // if(jet)
-
-    return pass;
+    return (isCentralLightJet(jet) ||
+            isCentralBJet(jet) ||
+            isForwardJet(jet));
 }
 //----------------------------------------------------------
 bool JetSelector::isBJet(const Jet* jet)
 {
-    ///////////////////////////////
-    // pT requirement
-    ///////////////////////////////
-    if(jet->Pt() < 20.0)    return false;
-
-    ///////////////////////////////
-    // eta requirement
-    ///////////////////////////////
-    if(fabs(jet->Eta()) > 2.5) return false;
-
-    ///////////////////////////////
-    // jvt requirement
-    ///////////////////////////////
-    if(!jetPassesJvtRequirement(jet)) return false;
-
-    ///////////////////////////////
-    // mv2c20 cut
-    ///////////////////////////////
-    if(jet->mv2c20 < JET_MV2C20_77) return false;
-
-    return true;
+    return ((jet->Pt()        > 20.0   ) &&
+            (fabs(jet->Eta()) <  2.5   ) &&
+            (jet->mv2c20      > -0.4434) && // 77% eff
+            (jetPassesJvtRequirement(jet)));
 }
 //----------------------------------------------------------
 bool JetSelector::isCentralLightJet(const Jet* jet)
 {
-    JetSelector::check();
-
-    //////////////////////////////
-    // pt requirement
-    //////////////////////////////
-    if(jet->Pt() < JET_MIN_PT_L20)       return false;
-
-    //////////////////////////////
-    // detector eta requirement
-    //////////////////////////////
-    if(fabs(jet->detEta) > JET_MAX_ETA)  return false;
-
-    //////////////////////////////
-    // JVT requirement
-    //////////////////////////////
-    if(!jetPassesJvtRequirement(jet))    return false;
-
-    //////////////////////////////
-    // MV2c20 requirement
-    //   (a la SUSYTools)
-    //////////////////////////////
-    if(jet->bjet)                        return false;
-
-    return true;
-
+    bool pass = false;
+    if(jet) {
+        pass = (jet->Pt()         > 20.0 &&
+                fabs(jet->detEta) <  2.4 &&
+                jetPassesJvtRequirement(jet) &&
+                !isBJet(jet));
+    }
+    return pass;
 }
 //----------------------------------------------------------
 bool JetSelector::isCentralBJet(const Jet* jet)
 {
-    JetSelector::check();
-
-    //////////////////////////////
-    // pt requirement
-    //////////////////////////////
-    if(jet->Pt() < JET_MIN_PT_B20)            return false;
- 
-    //////////////////////////////
-    // detector eta requirement
-    //////////////////////////////
-    if(fabs(jet->detEta) > JET_MAX_ETA)       return false;
-
-    //////////////////////////////
-    // JVT requirement
-    //////////////////////////////
-    if(!jetPassesJvtRequirement(jet))         return false;
-
-    //////////////////////////////
-    // MV2c20 requirement
-    //   (a la SUSYTools)
-    //////////////////////////////
-    if(!jet->bjet)                            return false;
-
-    return true;
+    bool pass = false;
+    if(jet) {
+        pass = (jet->Pt()         > 20.0 &&
+                fabs(jet->detEta) <  2.4 &&
+                jetPassesJvtRequirement(jet) &&
+                isBJet(jet));
+    }
+    return pass;
 }
 //----------------------------------------------------------
 bool JetSelector::isForwardJet(const Jet* jet)
 {
-    JetSelector::check();
-
-    //////////////////////////////
-    // pt requirement
-    //////////////////////////////
-    if(jet->Pt() < JET_MIN_PT_F30)            return false;
-
-    //////////////////////////////
-    // jet in forward direction?
-    //////////////////////////////
-    if(fabs(jet->detEta) < JET_MAX_ETA)       return false;
-
-    //////////////////////////////
-    // jet eta below the max?
-    //////////////////////////////
-    if(fabs(jet->detEta) > JET_MAX_ETA_FORWARD)   return false;
-
-    return true;
+    bool pass = false;
+    if(jet) {
+        pass = (jet->Pt()         > 30.0 &&
+                fabs(jet->detEta) >  2.4 &&
+                fabs(jet->detEta) <  4.5 );
+    }
+    return pass;
 }
 //----------------------------------------------------------
+/*
+  Threshold as recommended at
+  https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Jets
+*/
 bool JetSelector::jetPassesJvtRequirement(const Jet* jet)
 {
-    JetSelector::check();
-
-    return ((jet->jvt > JET_JVT_CUT)
-                || (fabs(jet->detEta) > JET_JVT_ETA_CUT)
-                || (jet->Pt() > JET_JVT_PT_CUT));
+    bool pass = false;
+    if(jet) {
+        pass = ((jet->jvt          >  0.64) ||
+                (fabs(jet->detEta) >  2.4)  ||
+                (jet->Pt()         > 50.0)  );
+    }
+    return pass;
 }
 //----------------------------------------------------------
 size_t JetSelector::count_CL_jets(const JetVector &jets)
 {
-    JetSelector::check();
-
     return std::count_if(jets.begin(), jets.end(),
                          std::bind1st(std::mem_fun(&JetSelector::isCentralLightJet), this));
 }
 //----------------------------------------------------------
 size_t JetSelector::count_CB_jets(const JetVector &jets)
 {
-    JetSelector::check();
-
-    return std::count_if(jets.begin(), jets.end(), 
+    return std::count_if(jets.begin(), jets.end(),
                          std::bind1st(std::mem_fun(&JetSelector::isCentralBJet), this));
 }
 //----------------------------------------------------------
 size_t JetSelector::count_F_jets(const JetVector &jets)
 {
-    JetSelector::check();
-
     return std::count_if(jets.begin(), jets.end(),
                             std::bind1st(std::mem_fun(&JetSelector::isForwardJet), this));
 }
 //----------------------------------------------------------
-void JetSelector::check()
-{
-    if(m_analysis == AnalysisType::kUnknown) {
-        string error = "JetSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for JetSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for JetSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    return;
-}
-////----------------------------------------------------------
 
+//----------------------------------------------------------
+// begin JetSelector_2Lep
+//----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin JetSelector_3Lep
+//----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin JetSelector_2LepWH
+//----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin JetSelector_ss3l
+//----------------------------------------------------------
+bool JetSelector_ss3l::isBaselineJet(const Jet* jet)
+{
+    bool pass = false;
+    if(jet){
+        pass = (jet->Pt()        > 20.0 &&
+                fabs(jet->Eta()) <  2.8 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector_ss3l::isSignalJet(const Jet* jet)
+{
+    bool pass = false;
+    if(jet) {
+        pass = (isBaselineJet(jet) &&
+                jet->Pt()        > 20.0 &&
+                fabs(jet->Eta()) <  2.8 &&
+                passJvt(jet)            );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector_ss3l::isBJet(const Jet* jet)
+{
+    bool pass = false;
+    if(jet) {
+        pass = (jet->Pt()        > 20.0    &&
+                fabs(jet->Eta()) <  2.4    &&
+                passJvt(jet)               &&
+                jet->mv2c20      > -0.0436 ); // 70% eff
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector_ss3l::passJvt(const Jet* jet)
+{
+    bool pass = false;
+    if(jet) {
+        if(jet->Pt()<50.0 &&
+           fabs(jet->Eta())<2.4 &&
+           jet->jvt < 0.64)
+            pass = false;
+        else pass = true;
+    }
+    return pass;
+}
+//----------------------------------------------------------
+// begin JetSelector_Stop2L
+// TODO Danny please check values
+//----------------------------------------------------------
+bool JetSelector_Stop2L::isBaselineJet(const Jet* jet)
+{
+    bool pass = false;
+    if(jet) {
+        pass = (fabs(jet->Eta()) <  2.4 &&
+                jet->Pt()        > 20.0 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool JetSelector_Stop2L::isSignalJet(const Jet* jet)
+{
+    bool pass = false;
+    if(jet) {
+        pass =((jet->Pt()        > 20.0) &&
+               (fabs(jet->Eta()) >  2.8) &&
+               jetPassesJvtRequirement(jet));
+    }
+    return pass;
+}
+//----------------------------------------------------------
 } // Susy namespace

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -42,19 +42,19 @@ JetSelector& JetSelector::setSystematic(const NtSys::SusyNtSys &s)
     return *this;
 }
 //----------------------------------------------------------
-bool JetSelector::isBaselineJet(const Jet* jet)
+bool JetSelector::isBaseline(const Jet* jet)
 {
     return (jet->Pt() > 20.0);
 }
 //----------------------------------------------------------
-bool JetSelector::isSignalJet(const Jet* jet)
+bool JetSelector::isSignal(const Jet* jet)
 {
-    return (isCentralLightJet(jet) ||
-            isCentralBJet(jet) ||
-            isForwardJet(jet));
+    return (isCentralLight(jet) ||
+            isCentralB(jet) ||
+            isForward(jet));
 }
 //----------------------------------------------------------
-bool JetSelector::isBJet(const Jet* jet)
+bool JetSelector::isB(const Jet* jet)
 {
     return ((jet->Pt()        > 20.0   ) &&
             (fabs(jet->Eta()) <  2.5   ) &&
@@ -62,31 +62,31 @@ bool JetSelector::isBJet(const Jet* jet)
             (passJvt(jet)));
 }
 //----------------------------------------------------------
-bool JetSelector::isCentralLightJet(const Jet* jet)
+bool JetSelector::isCentralLight(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
         pass = (jet->Pt()         > 20.0 &&
                 fabs(jet->detEta) <  2.4 &&
                 passJvt(jet) &&
-                !isBJet(jet));
+                !isB(jet));
     }
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector::isCentralBJet(const Jet* jet)
+bool JetSelector::isCentralB(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
         pass = (jet->Pt()         > 20.0 &&
                 fabs(jet->detEta) <  2.4 &&
                 passJvt(jet) &&
-                isBJet(jet));
+                isB(jet));
     }
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector::isForwardJet(const Jet* jet)
+bool JetSelector::isForward(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
@@ -115,19 +115,19 @@ bool JetSelector::passJvt(const Jet* jet)
 size_t JetSelector::count_CL_jets(const JetVector &jets)
 {
     return std::count_if(jets.begin(), jets.end(),
-                         std::bind1st(std::mem_fun(&JetSelector::isCentralLightJet), this));
+                         std::bind1st(std::mem_fun(&JetSelector::isCentralLight), this));
 }
 //----------------------------------------------------------
 size_t JetSelector::count_CB_jets(const JetVector &jets)
 {
     return std::count_if(jets.begin(), jets.end(),
-                         std::bind1st(std::mem_fun(&JetSelector::isCentralBJet), this));
+                         std::bind1st(std::mem_fun(&JetSelector::isCentralB), this));
 }
 //----------------------------------------------------------
 size_t JetSelector::count_F_jets(const JetVector &jets)
 {
     return std::count_if(jets.begin(), jets.end(),
-                            std::bind1st(std::mem_fun(&JetSelector::isForwardJet), this));
+                            std::bind1st(std::mem_fun(&JetSelector::isForward), this));
 }
 //----------------------------------------------------------
 
@@ -146,7 +146,7 @@ size_t JetSelector::count_F_jets(const JetVector &jets)
 //----------------------------------------------------------
 // begin JetSelector_SS3L
 //----------------------------------------------------------
-bool JetSelector_SS3L::isBaselineJet(const Jet* jet)
+bool JetSelector_SS3L::isBaseline(const Jet* jet)
 {
     bool pass = false;
     if(jet){
@@ -156,11 +156,11 @@ bool JetSelector_SS3L::isBaselineJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_SS3L::isSignalJet(const Jet* jet)
+bool JetSelector_SS3L::isSignal(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
-        pass = (isBaselineJet(jet) &&
+        pass = (isBaseline(jet) &&
                 jet->Pt()        > 20.0 &&
                 fabs(jet->Eta()) <  2.8 &&
                 passJvt(jet)            );
@@ -168,7 +168,7 @@ bool JetSelector_SS3L::isSignalJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_SS3L::isBJet(const Jet* jet)
+bool JetSelector_SS3L::isB(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
@@ -183,7 +183,7 @@ bool JetSelector_SS3L::isBJet(const Jet* jet)
 // begin JetSelector_Stop2L
 // TODO Danny please check values
 //----------------------------------------------------------
-bool JetSelector_Stop2L::isBaselineJet(const Jet* jet)
+bool JetSelector_Stop2L::isBaseline(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
@@ -193,7 +193,7 @@ bool JetSelector_Stop2L::isBaselineJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_Stop2L::isSignalJet(const Jet* jet)
+bool JetSelector_Stop2L::isSignal(const Jet* jet)
 {
     bool pass = false;
     if(jet) {

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -181,14 +181,12 @@ bool JetSelector_SS3L::isB(const Jet* jet)
 }
 //----------------------------------------------------------
 // begin JetSelector_Stop2L
-// TODO Danny please check values
 //----------------------------------------------------------
 bool JetSelector_Stop2L::isBaseline(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
-        pass = (fabs(jet->Eta()) <  2.4 &&
-                jet->Pt()        > 20.0 );
+        pass = (jet->Pt()        > 20.0 );
     }
     return pass;
 }
@@ -197,8 +195,8 @@ bool JetSelector_Stop2L::isSignal(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
-        pass =((jet->Pt()        > 20.0) &&
-               (fabs(jet->Eta()) >  2.8) &&
+        pass =(jet->Pt()        > 20.0 &&
+               fabs(jet->Eta()) >  2.8 &&
                passJvt(jet));
     }
     return pass;

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -61,7 +61,7 @@ bool JetSelector::isBJet(const Jet* jet)
     return ((jet->Pt()        > 20.0   ) &&
             (fabs(jet->Eta()) <  2.5   ) &&
             (jet->mv2c20      > -0.4434) && // 77% eff
-            (jetPassesJvtRequirement(jet)));
+            (passJvt(jet)));
 }
 //----------------------------------------------------------
 bool JetSelector::isCentralLightJet(const Jet* jet)
@@ -70,7 +70,7 @@ bool JetSelector::isCentralLightJet(const Jet* jet)
     if(jet) {
         pass = (jet->Pt()         > 20.0 &&
                 fabs(jet->detEta) <  2.4 &&
-                jetPassesJvtRequirement(jet) &&
+                passJvt(jet) &&
                 !isBJet(jet));
     }
     return pass;
@@ -82,7 +82,7 @@ bool JetSelector::isCentralBJet(const Jet* jet)
     if(jet) {
         pass = (jet->Pt()         > 20.0 &&
                 fabs(jet->detEta) <  2.4 &&
-                jetPassesJvtRequirement(jet) &&
+                passJvt(jet) &&
                 isBJet(jet));
     }
     return pass;
@@ -103,7 +103,7 @@ bool JetSelector::isForwardJet(const Jet* jet)
   Threshold as recommended at
   https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Jets
 */
-bool JetSelector::jetPassesJvtRequirement(const Jet* jet)
+bool JetSelector::passJvt(const Jet* jet)
 {
     bool pass = false;
     if(jet) {
@@ -182,19 +182,6 @@ bool JetSelector_ss3l::isBJet(const Jet* jet)
     return pass;
 }
 //----------------------------------------------------------
-bool JetSelector_ss3l::passJvt(const Jet* jet)
-{
-    bool pass = false;
-    if(jet) {
-        if(jet->Pt()<50.0 &&
-           fabs(jet->Eta())<2.4 &&
-           jet->jvt < 0.64)
-            pass = false;
-        else pass = true;
-    }
-    return pass;
-}
-//----------------------------------------------------------
 // begin JetSelector_Stop2L
 // TODO Danny please check values
 //----------------------------------------------------------
@@ -214,7 +201,7 @@ bool JetSelector_Stop2L::isSignalJet(const Jet* jet)
     if(jet) {
         pass =((jet->Pt()        > 20.0) &&
                (fabs(jet->Eta()) >  2.8) &&
-               jetPassesJvtRequirement(jet));
+               passJvt(jet));
     }
     return pass;
 }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -56,7 +56,7 @@ MuonSelector::MuonSelector():
 {
 }
 //----------------------------------------------------------
-bool MuonSelector::isBaselineMuon(const Muon* mu)
+bool MuonSelector::isBaseline(const Muon* mu)
 {
     // works for Ana_2Lep, Ana_3Lep, Ana_2LepWH
     bool pass = false;
@@ -68,7 +68,7 @@ bool MuonSelector::isBaselineMuon(const Muon* mu)
     return pass;
 }
 //----------------------------------------------------------
-bool MuonSelector::isSignalMuon(const Muon* mu)
+bool MuonSelector::isSignal(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
@@ -119,11 +119,11 @@ float MuonSelector::errEffSF(const Muon& mu, const SusyNtSys sys)
 //----------------------------------------------------------
 // begin MuonSelector_3Lep
 //----------------------------------------------------------
-bool MuonSelector_3Lep::isSignalMuon(const Muon* mu)
+bool MuonSelector_3Lep::isSignal(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
-        pass = (isBaselineMuon(mu) &&
+        pass = (isBaseline(mu) &&
                 mu->isoTight &&
                 passIpCut(mu));
     }
@@ -133,11 +133,11 @@ bool MuonSelector_3Lep::isSignalMuon(const Muon* mu)
 //----------------------------------------------------------
 // begin MuonSelector_ss3l
 //----------------------------------------------------------
-bool MuonSelector_2LepWH::isSignalMuon(const Muon* mu)
+bool MuonSelector_2LepWH::isSignal(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
-        pass = (isBaselineMuon(mu) &&
+        pass = (isBaseline(mu) &&
                 mu->ptvarcone30/mu->Pt() < 0.06 && // note: isBaselineMuon guarantees pt>0
                 mu->etconetopo30/mu->Pt() < 0.14 && // was etcone?
                 passIpCut(mu));
@@ -157,7 +157,7 @@ bool MuonSelector_SS3L::passIpCut(const Muon* mu)
     return pass;
 }
 //----------------------------------------------------------
-bool MuonSelector_SS3L::isBaselineMuon(const Muon* mu)
+bool MuonSelector_SS3L::isBaseline(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
@@ -168,11 +168,11 @@ bool MuonSelector_SS3L::isBaselineMuon(const Muon* mu)
     return pass;
 }
 //----------------------------------------------------------
-bool MuonSelector_SS3L::isSignalMuon(const Muon* mu)
+bool MuonSelector_SS3L::isSignal(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
-        pass = (isBaselineMuon(mu) &&
+        pass = (isBaseline(mu) &&
                 mu->ptvarcone30/mu->Pt() < 0.06 && // note: isBaselineMuon guarantees pt>0
                 passIpCut(mu));
     }
@@ -192,7 +192,7 @@ bool MuonSelector_Stop2L::passIpCut(const Muon* mu)
     return pass;
 }
 //----------------------------------------------------------
-bool MuonSelector_Stop2L::isBaselineMuon(const Muon* mu)
+bool MuonSelector_Stop2L::isBaseline(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
@@ -203,12 +203,12 @@ bool MuonSelector_Stop2L::isBaselineMuon(const Muon* mu)
     return pass;
 }
 //----------------------------------------------------------
-bool MuonSelector_Stop2L::isSignalMuon(const Muon* mu)
+bool MuonSelector_Stop2L::isSignal(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
         pass = (mu->Pt() > 10.0 &&
-                isBaselineMuon(mu) &&
+                isBaseline(mu) &&
                 mu->isoGradientLoose &&
                 passIpCut(mu));
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -1,13 +1,10 @@
 #include "SusyNtuple/MuonSelector.h"
-#include "SusyNtuple/ElectronSelector.h"
-#include "SusyNtuple/SusyNt.h"
+#include "SusyNtuple/Muon.h"
 
 #include <algorithm>
 #include <cassert>
 #include <iostream>
 
-using Susy::MuonSelector;
-using Susy::Muon;
 using Susy::NtSys::SusyNtSys;
 using std::cout;
 using std::endl;

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -180,7 +180,6 @@ bool MuonSelector_SS3L::isSignal(const Muon* mu)
 }
 //----------------------------------------------------------
 // begin MuonSelector_Stop2L
-// TODO Danny please check values
 //----------------------------------------------------------
 bool MuonSelector_Stop2L::passIpCut(const Muon* mu)
 {
@@ -196,7 +195,7 @@ bool MuonSelector_Stop2L::isBaseline(const Muon* mu)
 {
     bool pass = false;
     if(mu) {
-        pass = (mu->loose &&
+        pass = (mu->medium &&
                 mu->Pt()        > 10.0 &&
                 fabs(mu->Eta()) <  2.4 );
     }

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -18,28 +18,28 @@ MuonSelector* MuonSelector::build(const AnalysisType &a, bool verbose)
     switch(a) {
     case AnalysisType::Ana_2Lep   :
         s = new MuonSelector_2Lep();
-        s->setSignalMuonId(MuonId::Medium);
-        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        s->setSignalId(MuonId::Medium);
+        s->setSignalIsolation(Isolation::GradientLoose);
         break;
     case AnalysisType::Ana_3Lep   :
         s = new MuonSelector_3Lep();
-        s->setSignalMuonId(MuonId::Medium);
-        s->setSignalMuonIsolation(Isolation::Tight);
+        s->setSignalId(MuonId::Medium);
+        s->setSignalIsolation(Isolation::Tight);
         break;
     case AnalysisType::Ana_2LepWH :
         s = new MuonSelector_2LepWH();
-        s->setSignalMuonId(MuonId::Medium);
-        s->setSignalMuonIsolation(Isolation::Tight);
+        s->setSignalId(MuonId::Medium);
+        s->setSignalIsolation(Isolation::Tight);
         break;
     case AnalysisType::Ana_SS3L   :
         s = new MuonSelector_SS3L();
-        s->setSignalMuonId(MuonId::Medium);
-        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        s->setSignalId(MuonId::Medium);
+        s->setSignalIsolation(Isolation::GradientLoose);
         break;
     case AnalysisType::Ana_Stop2L :
         s = new MuonSelector_Stop2L();
-        s->setSignalMuonId(MuonId::Loose);
-        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        s->setSignalId(MuonId::Loose);
+        s->setSignalIsolation(Isolation::GradientLoose);
         break;
     default:
         cout<<"MuonSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -14,308 +14,208 @@ using std::endl;
 using std::string;
 
 namespace Susy {
-
-// -------------------------------------------------------------------------------------------- //
-// Constructor
-// -------------------------------------------------------------------------------------------- //
-MuonSelector::MuonSelector() :
-    //////////////////////////////////
-    // default selection
-    //////////////////////////////////
-    MU_MIN_PT_BASELINE(10.0),
-    MU_MIN_PT_SIGNAL(10.0),
-    MU_MAX_ETA_BASELINE(2.4),
-    MU_MAX_ETA_SIGNAL(2.4),
-    MU_ISO_PT_THRS(60.0),
-    MU_PTCONE30_SLOPE_DATA(0.01098),
-    MU_PTCONE30_SLOPE_MC(0.00627),
-    MU_PTCONE30_PT_CUT(0.12),
-    MU_ETCONE30_K1_DATA(0.0648),
-    MU_ETCONE30_K2_DATA(0.00098),
-    MU_ETCONE30_K1_MC(0.0692),
-    MU_ETCONE30_K2_MC(0.00076),
-    MU_ETCONE30_PT_CUT(0.12),
-    MU_MAX_D0SIG(3.0),
-    MU_MAX_Z0_SINTHETA(0.4), 
-    //////////////////////////////////
-    m_systematic(NtSys::NOM),
-    m_analysis(AnalysisType::kUnknown),
-    m_doIPCut(true),
-    m_muBaseId(MuonId::MuonIdInvalid),
-    m_muId(MuonId::MuonIdInvalid),
-    m_sigIso(Isolation::IsolationInvalid),
-    m_2lep(false),
-    m_3lep(false),
-    m_2lepWH(false),
+//----------------------------------------------------------
+MuonSelector* MuonSelector::build(const AnalysisType &a, bool verbose)
+{
+    MuonSelector *s;
+    switch(a) {
+    case AnalysisType::Ana_2Lep   :
+        s = new MuonSelector_2Lep();
+        s->setSignalMuonId(MuonId::Medium);
+        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_3Lep   :
+        s = new MuonSelector_3Lep();
+        s->setSignalMuonId(MuonId::Medium);
+        s->setSignalMuonIsolation(Isolation::Tight);
+        break;
+    case AnalysisType::Ana_2LepWH :
+        s = new MuonSelector_2LepWH();
+        s->setSignalMuonId(MuonId::Medium);
+        s->setSignalMuonIsolation(Isolation::Tight);
+        break;
+    case AnalysisType::Ana_SS3L   :
+        s = new MuonSelector_SS3L();
+        s->setSignalMuonId(MuonId::Medium);
+        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        break;
+    case AnalysisType::Ana_Stop2L :
+        s = new MuonSelector_Stop2L();
+        s->setSignalMuonId(MuonId::Loose);
+        s->setSignalMuonIsolation(Isolation::GradientLoose);
+        break;
+    default:
+        cout<<"MuonSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
+            <<" returning vanilla MuonSelector"<<endl;
+        s = new MuonSelector();
+    }
+    return s;
+}
+//----------------------------------------------------------
+MuonSelector::MuonSelector():
+    m_signalId(Susy::MuonId::MuonIdInvalid),
+    m_signalIsolation(Isolation::IsolationInvalid),
     m_verbose(false)
 {
 }
-// -------------------------------------------------------------------------------------------- //
-MuonSelector& MuonSelector::setAnalysis(const AnalysisType& a)
-{
-
-    //////////////////////////////////////
-    // Set analysis-specific cuts
-    //////////////////////////////////////
-
-    //////////////////////////////////////
-    // 2L-ANALYSIS
-    //////////////////////////////////////
-    if( a == AnalysisType::Ana_2Lep ) {
-        m_2lep  = true;
-
-        //baseline
-        m_muBaseId = MuonId::Medium;
-
-        //signal
-        m_muId = MuonId::Medium;
-        m_sigIso = Isolation::GradientLoose;
-        m_doIPCut           = true;
-    } 
-    //////////////////////////////////////
-    // 3L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_3Lep ) {
-        m_3lep  = true;
-
-        //baseline
-        m_muBaseId = MuonId::Medium;
-        //signal
-        m_muId = MuonId::Medium;
-        m_sigIso = Isolation::Tight;
-        m_doIPCut           = true;
-    }
-    //////////////////////////////////////
-    // WH-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_2LepWH ) {
-        m_2lepWH = true;
-
-        //baseline
-        m_muBaseId = MuonId::Medium;
-
-        //signal
-        m_muId = MuonId::Medium;
-        m_sigIso = Isolation::Tight;
-        m_doIPCut           = true;
-
-        // muons
-        MU_PTCONE30_PT_CUT = 0.06;
-        MU_ETCONE30_PT_CUT = 0.14;
-    }
-    //////////////////////////////////////
-    // SS3L-ANALYSIS
-    // values from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_SS3L ) {
-        m_SS3L  = true;
-        //baseline
-        m_muBaseId           = MuonId::Medium;
-        MU_MIN_PT_BASELINE   = 10.0;
-        MU_MAX_ETA_BASELINE  = 2.5;
-        //signal
-        m_muId               = MuonId::Medium;
-        m_sigIso             = Isolation::GradientLoose;
-        m_doIPCut            = true;
-        MU_MIN_PT_SIGNAL     = 10.0;
-        MU_MAX_ETA_SIGNAL    = 2.5;
-        MU_MAX_D0SIG         = 3.0;
-        MU_MAX_Z0_SINTHETA   = 0.5;
-
-    //////////////////////////////////
-    } 
-    //////////////////////////////////////
-    // Stop2L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_Stop2L ) {
-        m_stop2l = true;
-
-        //baseline
-        m_muBaseId = MuonId::Loose;
-
-        //signal
-        m_muId = MuonId::Loose;
-        m_sigIso = Isolation::GradientLoose;
-        m_doIPCut = true;
-
-        //cuts
-        MU_MAX_Z0_SINTHETA = 0.5;
-    }
-
-    //////////////////////////////////////
-    // Didn't set AnalysisType
-    //////////////////////////////////////
-    else if( a == AnalysisType::kUnknown ) {
-        string error  = "MuonSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for MuonSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for MuonSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    //////////////////////////////////////
-    // Gone fishin'
-    //////////////////////////////////////
-    else {
-        string error = "MuonSelector::setAnalysis error: ";
-        cout << error << "MuonSelector is not configured for the AnalysisType (" << AnalysisType2str(a) << ") provided in" << endl;
-        cout << error << "'setAnalysis'! Be sure that your AnalysisType is provided for in SusyNtuple/AnalysisType.h" << endl;
-        cout << error << "and that you provide the necessary requirements for your analysis in 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    m_analysis = a;
-
-    // check that the muon ID qualities are set
-    if(m_muBaseId == MuonId::MuonIdInvalid || m_muId == MuonId::MuonIdInvalid) {
-        string error = "MuonSelector::setAnalysis error: ";
-        cout << error << "Muon ID quality is not set." << endl;
-        cout << error << "Muon baseline ID quality = " << MuonId2str(m_muBaseId) << endl;
-        cout << error << "Muon signal ID quality   = " << MuonId2str(m_muId) << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    
-    // check the muon signal isolation has been set
-    if(m_sigIso == Isolation::IsolationInvalid) {
-        string error = "MuonSelector::setAnalysis error: ";
-        cout << error << "Signal muon isolation requirement is not set." << endl;
-        cout << error << "Muon isolation = " << Isolation2str(m_sigIso) << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    if(m_verbose)
-        cout << "MuonSelector    Configured muon selection for AnalysisType " << AnalysisType2str(m_analysis) << endl;
-
-    return *this;
-}
-
-// -------------------------------------------------------------------------------------------- //
-MuonSelector& MuonSelector::setSystematic(const NtSys::SusyNtSys &s)
-{
-    m_systematic = s;
-    return *this;
-}
-// -------------------------------------------------------------------------------------------- //
+//----------------------------------------------------------
 bool MuonSelector::isBaselineMuon(const Muon* mu)
 {
-    MuonSelector::check();
-
-   // if(!mu->medium)                    return false;
-    if(!muPassQuality(mu, false))      return false;
-    if(mu->Pt() < MU_MIN_PT_BASELINE)  return false;
-    if(fabs(mu->Eta()) > MU_MAX_ETA_BASELINE)   return false;
-
-    return true;
+    // works for Ana_2Lep, Ana_3Lep, Ana_2LepWH
+    bool pass = false;
+    if(mu) {
+        pass = (mu->medium &&
+                mu->Pt()        > 10.0 &&
+                fabs(mu->Eta()) <  2.4 );
+    }
+    return pass;
 }
-// -------------------------------------------------------------------------------------------- //
+//----------------------------------------------------------
 bool MuonSelector::isSignalMuon(const Muon* mu)
 {
-    MuonSelector::check();
-
-    if(!muPassQuality(mu, true)) return false;
-
-    //////////////////////////////
-    // Isolation
-    // (IsolationSelectionTool)
-    //////////////////////////////
-    if(!muPassIsolation(mu)) return false;
-
-    //////////////////////////////
-    // Impact parameter
-    //////////////////////////////
-    if (m_doIPCut) {
-        if(fabs(mu->d0sigBSCorr) >= MU_MAX_D0SIG)        return false;
-        if(fabs(mu->z0SinTheta()) >= MU_MAX_Z0_SINTHETA) return false;
+    bool pass = false;
+    if(mu) {
+        pass = (mu->Pt() > 10.0 &&
+                mu->medium &&
+                mu->isoGradientLoose &&
+                passIpCut(mu));
     }
-
-    //////////////////////////////
-    // mu pt
-    //////////////////////////////
-    if(mu->Pt() < MU_MIN_PT_SIGNAL) return false;
-
-    return true;
+    return pass;
 }
-// -------------------------------------------------------------------------------------------- //
-bool MuonSelector::isSemiSignalMuon(const Muon* mu)
+//----------------------------------------------------------
+bool MuonSelector::passIpCut(const Muon* mu)
 {
-    /////////////////////////////
-    // Impact parameter
-    /////////////////////////////
-    if(m_doIPCut) {
-        if(fabs(mu->d0sigBSCorr) >= MU_MAX_D0SIG) return false;
-        if(fabs(mu->z0SinTheta()) >= MU_MAX_Z0_SINTHETA) return false;
+    bool pass = false;
+    if(mu) {
+        pass = (fabs(mu->d0sigBSCorr)  < 3.0 &&
+                fabs(mu->z0SinTheta()) < 0.4 );
     }
-    return true;
+    return pass;
 }
-// -------------------------------------------------------------------------------------------- //
-bool MuonSelector::muPassQuality(const Muon* mu, bool signalQuality)
-{
-    MuonId id = signalQuality ? m_muId : m_muBaseId;
-
-    if     (id == MuonId::VeryLoose)    return mu->veryLoose;
-    else if(id == MuonId::Loose)        return mu->loose;
-    else if(id == MuonId::Medium)       return mu->medium;
-    else if(id == MuonId::Tight)        return mu->tight;
-    else {
-        cout << "MuonSelector::muPassQuality error: MuonId requirement for muons not set for " << (signalQuality ? "signal" : "baseline") << "-level muons." << endl;
-        cout << "MuonSelector::muPassQuality error: >>> Exiting." << endl;
-        exit(1);
-    }
-
-}
-// -------------------------------------------------------------------------------------------- //
-bool MuonSelector::muPassIsolation(const Muon* mu)
-{
-    if     (m_sigIso == Isolation::GradientLoose) return mu->isoGradientLoose;
-    else if(m_sigIso == Isolation::Gradient) return mu->isoGradient;
-    else if(m_sigIso == Isolation::LooseTrackOnly) return mu->isoLooseTrackOnly;
-    else if(m_sigIso == Isolation::Loose) return mu->isoLoose;
-    else if(m_sigIso == Isolation::Tight) return mu->isoTight;
-    else {
-        cout << "MuonSelector::muPassIsolation error: isolation requirement for muons not set to signal-level isolation (Loose or Tight)" << endl;
-        cout << "MuonSelector::muPassIsolation error: >>> Exiting." << endl;
-        exit(1);
-    }
-}
-// -------------------------------------------------------------------------------------------- //
+//----------------------------------------------------------
 float MuonSelector::effSF(const Muon& mu)
 {
-    MuonSelector::check();
     // return the EffSF for the corresponding (signal) muon quality
-    return mu.muoEffSF[m_muId];
+    return mu.muoEffSF[m_signalId];
 }
-// -------------------------------------------------------------------------------------------- //
+//----------------------------------------------------------
 float MuonSelector::errEffSF(const Muon& mu, const SusyNtSys sys)
 {
-    MuonSelector::check();
     // return the error on the muon SF associated with systematc sys
     float err = 0.0;
     if(sys == NtSys::MUONSFSTAT_UP) {
-        err = mu.errEffSF_stat_up[m_muId];
-    }
-    else if(sys == NtSys::MUONSFSTAT_DN) {
-        err = mu.errEffSF_stat_dn[m_muId];
-    }
-    else if(sys == NtSys::MUONSFSYS_UP) {
-        err = mu.errEffSF_syst_up[m_muId];
-    }
-    else if(sys == NtSys::MUONSFSYS_DN) {
-        err = mu.errEffSF_syst_dn[m_muId];
+        err = mu.errEffSF_stat_up[m_signalId];
+    } else if(sys == NtSys::MUONSFSTAT_DN) {
+        err = mu.errEffSF_stat_dn[m_signalId];
+    } else if(sys == NtSys::MUONSFSYS_UP) {
+        err = mu.errEffSF_syst_up[m_signalId];
+    } else if(sys == NtSys::MUONSFSYS_DN) {
+        err = mu.errEffSF_syst_dn[m_signalId];
+    } else {
+        cout<<"MuonSelector::errEffSF(): you are calling this function with"
+            <<" sys '"<<NtSys::SusyNtSysNames[sys]<<"'."
+            <<" This is not a muon sys. Returning "<<err
+            <<endl;
     }
     return err;
 }
-// -------------------------------------------------------------------------------------------- //
-void MuonSelector::check()
+//----------------------------------------------------------
+// begin MuonSelector_3Lep
+//----------------------------------------------------------
+bool MuonSelector_3Lep::isSignalMuon(const Muon* mu)
 {
-    if(m_analysis == AnalysisType::kUnknown) {
-        string error  = "MuonSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for MuonSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for MuonSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
+    bool pass = false;
+    if(mu) {
+        pass = (isBaselineMuon(mu) &&
+                mu->isoTight &&
+                passIpCut(mu));
     }
-    return;
+    return pass;
 }
+
+//----------------------------------------------------------
+// begin MuonSelector_ss3l
+//----------------------------------------------------------
+bool MuonSelector_2LepWH::isSignalMuon(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (isBaselineMuon(mu) &&
+                mu->ptvarcone30/mu->Pt() < 0.06 && // note: isBaselineMuon guarantees pt>0
+                mu->etconetopo30/mu->Pt() < 0.14 && // was etcone?
+                passIpCut(mu));
+    }
+    return pass;
+}
+//----------------------------------------------------------
+// begin MuonSelector_ss3l
+//----------------------------------------------------------
+bool MuonSelector_SS3L::passIpCut(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (fabs(mu->d0sigBSCorr)  < 3.0 &&
+                fabs(mu->z0SinTheta()) < 0.5 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool MuonSelector_SS3L::isBaselineMuon(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (mu->medium &&
+                mu->Pt()        > 10.0 &&
+                fabs(mu->Eta()) <  2.5 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool MuonSelector_SS3L::isSignalMuon(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (isBaselineMuon(mu) &&
+                mu->ptvarcone30/mu->Pt() < 0.06 && // note: isBaselineMuon guarantees pt>0
+                passIpCut(mu));
+    }
+    return pass;
+}
+//----------------------------------------------------------
+// begin MuonSelector_Stop2L
+// TODO Danny please check values
+//----------------------------------------------------------
+bool MuonSelector_Stop2L::passIpCut(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (fabs(mu->d0sigBSCorr)  < 3.0 &&
+                fabs(mu->z0SinTheta()) < 0.5 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool MuonSelector_Stop2L::isBaselineMuon(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (mu->loose &&
+                mu->Pt()        > 10.0 &&
+                fabs(mu->Eta()) <  2.4 );
+    }
+    return pass;
+}
+//----------------------------------------------------------
+bool MuonSelector_Stop2L::isSignalMuon(const Muon* mu)
+{
+    bool pass = false;
+    if(mu) {
+        pass = (mu->Pt() > 10.0 &&
+                isBaselineMuon(mu) &&
+                mu->isoGradientLoose &&
+                passIpCut(mu));
+    }
+    return pass;
+}
+//----------------------------------------------------------
 }; // namespace Susy

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -14,205 +14,69 @@ using std::string;
 
 
 namespace Susy {
-
-
-// ------------------------------------------------------------------------------ //
-// Constructor
-// ------------------------------------------------------------------------------ //
+//----------------------------------------------------------
+OverlapTools* OverlapTools::build(const AnalysisType &a, bool verbose)
+{
+    OverlapTools *o;
+    switch(a) {
+    case AnalysisType::Ana_2Lep   :
+        o = new OverlapTools_2Lep();
+        break;
+    case AnalysisType::Ana_3Lep   :
+        o = new OverlapTools_3Lep();
+        break;
+    case AnalysisType::Ana_2LepWH :
+        o = new OverlapTools_2LepWH();
+        break;
+    case AnalysisType::Ana_SS3L   :
+        o = new OverlapTools_SS3L();
+        break;
+    case AnalysisType::Ana_Stop2L :
+        o = new OverlapTools_Stop2L();
+        break;
+    default:
+        cout<<"OverlapTools::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
+            <<" returning vanilla OverlapTools"<<endl;
+        o = new OverlapTools();
+    }
+    return o;
+}
+//----------------------------------------------------------
 OverlapTools::OverlapTools() :
-    m_analysis(AnalysisType::kUnknown),
-    m_useSignalLeptons(false),
-    m_useIsoLeptons(false),
     m_electronIsolation(Isolation::IsolationInvalid),
     m_muonIsolation(Isolation::IsolationInvalid),
-    m_mv2c20_ORcut(-999),
-    m_doBjetOR(false),
     m_verbose(false)
 {
 }
-// ------------------------------------------------------------------------------ //
-OverlapTools& OverlapTools::setAnalysis(const AnalysisType& a)
-{
-
-    ////////////////////////////////////////
-    // Set analysis-specific OR procedures
-    ////////////////////////////////////////
-    
-    ///////////////////////////////////
-    // Contrarian analyses
-    ///////////////////////////////////
-    if( a == AnalysisType::Ana_2Lep   ||
-        a == AnalysisType::Ana_3Lep   ||
-        a == AnalysisType::Ana_2LepWH ||
-        a == AnalysisType::Ana_Stop2L ) {
-        m_useSignalLeptons = false;
-        m_useIsoLeptons    = false;
-        m_doBjetOR         = false;
-    }
-    ///////////////////////////////////
-    // SS3L-ANALYSIS
-    ///////////////////////////////////
-    else if ( a == AnalysisType::Ana_SS3L ) {
-        // change muon-jet dr
-        M_J_DR = 0.2;
-        m_useSignalLeptons = false;
-        m_useIsoLeptons    = false;
-        m_doBjetOR         = true;
-    }
-    ///////////////////////////////////
-    // Didn't set AnalysisType
-    ///////////////////////////////////
-    else if ( a == AnalysisType::kUnknown ) {
-        string error = "OverlapTools::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for OverlapTools. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for OverlapTools for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    ///////////////////////////////////
-    // Gone fishin'
-    ///////////////////////////////////
-    else {
-        string error = "OverlapTools::setAnalysis error: ";
-        cout << error << "OverlapTools is not configured for the AnalysisType (" << AnalysisType2str(a) << ") provided in " << endl;
-        cout << error << "'setAnalysis'! Be sure that your AnalysisType is provided for in SusyNtuple/AnalysisType.h" << endl;
-        cout << error << "and that you provide the necessary requirements for your analysis in 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    
-    m_analysis = a;
-
-    // check that ele/muon isolation has been set if we are using isolated leptons
-    if(useIsolatedLeptons() && (m_electronIsolation==Isolation::IsolationInvalid || m_muonIsolation==Isolation::IsolationInvalid)) {
-        string error = "OverlapTools::setAnalysis error: ";
-        cout << error << "You have configured the overlap removal to use isolated leptons but" << endl;
-        cout << error << "have not set the electron and/or muon isolation qualities:" << endl;
-        cout << error << " > Electron isolation = " << Isolation2str(m_electronIsolation) << endl;
-        cout << error << " > Muon isolation = " << Isolation2str(m_muonIsolation) << endl;
-        cout << error << "You must use the 'setElectronIsolation' and 'setMuonIsolation' methods of" << endl;
-        cout << error << "OverlapTools to set these values prior to calling 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1); 
-    }
-
-    // check that the b-tag WP has been set if we are using the b-jet OR procedure
-    if(doBjetOR() && (m_mv2c20_ORcut==-999)) {
-        string error = "OverlapTools::setAnalysis error: ";
-        cout << error << "You have configured the overlap removal to use the b-jet OR procedure but" << endl;
-        cout << error << "have not set the b-tag WP (MV2C20 score) to use." << endl;
-        cout << error << "You must use the 'setORBtagEff' methods of OverlapTools to set this value" << endl;
-        cout << error << "prior to calling 'setAnalysis'." << endl;
-        cout << error << "The recommended MV2C20 cut value is provided by the JetSelector method" << endl;
-        cout << error << "'overlapRemovalBtagEffWP()'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    cout << "OverlapTools    Configured overlap removal procedure for AnalysisType " << AnalysisType2str(m_analysis) << endl;
-    cout << "OverlapTools     > using signal leptons    : " << (m_useSignalLeptons ? "True" : "False") << endl;
-    cout << "OverlapTools     > using isolated leptons  : " << (m_useIsoLeptons ? "True" : "False");
-    if(m_useIsoLeptons && m_verbose) cout << " (with electron isolation: " << Isolation2str(m_electronIsolation) << " and muon isolation: " << Isolation2str(m_muonIsolation) << ")" << endl;
-    else { cout << endl; }
-    cout << "OverlapTools     > doing b-jet OR procedure: " << (m_doBjetOR ? "True" : "False");
-    if(m_doBjetOR && m_verbose) cout << " (with MV2C20 cut: " << m_mv2c20_ORcut << ")" << endl;
-    else { cout << endl; }
-
-    return *this;
-}
-// ------------------------------------------------------------------------------ //
-// Main overlap removal function
-// ------------------------------------------------------------------------------ //
-
+//----------------------------------------------------------
 void OverlapTools::performOverlap(ElectronVector& electrons, MuonVector& muons,
                                     TauVector& taus, JetVector& jets)
 {
-    OverlapTools::check();
-
     /** Following the rel20/13TeV prescription described in:
-    https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Overlap_Removals
+        https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Overlap_Removals
     */
 
-    ///////////////////////////////////////////
-    // If using isolated leptons in OR, remove
-    // the non-isolated leptons
-    // --> using GradientLoose WP for isolation
-    //     (this is default in SUSYTools)
-    ///////////////////////////////////////////
-    if(useIsolatedLeptons()){
-        for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
-            const Electron* e = electrons.at(iEl);
-            if(!leptonPassesIsolation(e, true)) { electrons.erase(electrons.begin()+iEl); continue; }
-            //if(!e->isoGradientLoose) { electrons.erase(electrons.begin() + iEl); continue; }
-        }
-        for(int iMu=muons.size()-1; iMu>=0; iMu--) {
-            const Muon* m = muons.at(iMu);
-            if(!leptonPassesIsolation(m, false)) { muons.erase(muons.begin()+iMu); continue; }
-            //if(!m->isoGradientLoose) { muons.erase(muons.begin() + iMu); continue; }
-        }
-    }
-
-    ///////////////////////////////////////////
-    // Remove jets overlapping with electrons
-    ///////////////////////////////////////////
-    j_e_overlap(electrons, jets);
-
-    ///////////////////////////////////////////
-    // Remove electrons overlapping with jets
-    ///////////////////////////////////////////
-    e_j_overlap(electrons, jets);
-
-    ///////////////////////////////////////////
-    // Remove muons overlapping with jets
-    ///////////////////////////////////////////
-    m_j_overlap(muons, jets);
-
-    ///////////////////////////////////////////
-    // Remove electrons and muons that overlap
-    ///////////////////////////////////////////
-    e_m_overlap(electrons, muons);
-
-    ///////////////////////////////////////////
-    // Remove electrons that overlap with 
-    // each other
-    ///////////////////////////////////////////
-    e_e_overlap(electrons);
-/*    
+    j_e_overlap(electrons, jets, 0.2); // was J_E_DR
+    e_j_overlap(electrons, jets, 0.4); // was E_J_DR
+    m_j_overlap(muons, jets, 0.4); // was M_J_DR
+    e_m_overlap(electrons, muons, 0.01); // was E_M_DR
+    e_e_overlap(electrons, 0.05); // was E_E_DR
+/*
     // dantrim May 4 2015
-    // SUSYTools does not include the tau-related OR
-    // neither for harmonized nor for Run-1
-    // so will keep these commented for now
+    // SUSYTools does not include the tau-related OR neither for
+    // harmonized nor for Run-1 so will keep these commented for now
 
-    ///////////////////////////////////////////
-    // Remove muons that overlap with 
-    // each other
-    ///////////////////////////////////////////
-    m_m_overlap(muons);
-
-    ///////////////////////////////////////////
-    // Remove taus overlapping with electrons
-    ///////////////////////////////////////////
-    t_e_overlap(taus, electrons);
-    
-    ///////////////////////////////////////////
-    // Remove taus overlapping with muons
-    ///////////////////////////////////////////
-    t_m_overlap(taus, muons);
-
-    ///////////////////////////////////////////
-    // Remove jets overlapping with taus
-    ///////////////////////////////////////////
-    j_t_overlap(taus, jets);
+    m_m_overlap(muons, 0.05); // was M_M_DR
+    t_e_overlap(taus, electrons, 0.2);  // was T_E_DR
+    t_m_overlap(taus, muons, 0.2);  // was T_M_DR
+    j_t_overlap(taus, jets, 0.2);  // was J_T_DR
 
 */
 
 }
-
-bool OverlapTools::leptonPassesIsolation(const Lepton* lep, bool isEle)
+//----------------------------------------------------------
+bool OverlapTools::leptonPassesIsolation(const Lepton* lep, const Isolation &iso)
 {
-    OverlapTools::check();
-
-    Isolation iso = isEle ? m_electronIsolation : m_muonIsolation;
 
     if      (iso == Isolation::GradientLoose)   return lep->isoGradientLoose;
     else if (iso == Isolation::Gradient)        return lep->isoGradient;
@@ -220,90 +84,70 @@ bool OverlapTools::leptonPassesIsolation(const Lepton* lep, bool isEle)
     else if (iso == Isolation::Loose)           return lep->isoLoose;
     else if (iso == Isolation::Tight)           return lep->isoTight;
     else {
-        cout << "OverlapTools::leptonPassesIsolation error: isolation requirement for leptons not set." << endl;
-        cout << "OverlapTools::leptonPassesIsolation error:   >>> Exiting." << endl;
+        cout<<"OverlapTools::leptonPassesIsolation:"
+            <<" unknown isolation '"<<Isolation2str(iso)<<"'."<<endl;
         exit(1);
     }
 }
-
-// ------------------------------------------------------------------------------ //
-// Components of Overlap Removal
-// -----------------------------------------------------------------------------  //
-
-////////////////////////////////////////////
-// Remove jets overlapping with electrons
-//  J_E_DR = 0.2
-///////////////////////////////////////////
-void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets)
+//----------------------------------------------------------
+void OverlapTools::removeNonisolatedLeptons(ElectronVector& electrons, MuonVector& muons)
 {
-    /////////////////////////
-    // update
-    /////////////////////////
-    if(electrons.size()==0 || jets.size()==0) return;
-    for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
+    if(m_electronIsolation==Isolation::IsolationInvalid ||
+       m_muonIsolation==Isolation::IsolationInvalid) {
+        cout<<"OverlapTools::removeNonisolatedLeptons:"
+            <<" you need to call setElectronIsolation() and setMuonIsolation() first."
+            <<endl;
+        exit(1);
+    }
+    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--) {
         const Electron* e = electrons.at(iEl);
-        for(int iJ=jets.size()-1; iJ>=0; iJ--){
+        if(!leptonPassesIsolation(e, m_electronIsolation)) { electrons.erase(electrons.begin()+iEl); continue; }
+    }
+    for(size_t iMu=muons.size()-1; iMu>=0; iMu--) {
+        const Muon* m = muons.at(iMu);
+        if(!leptonPassesIsolation(m, m_muonIsolation)) { muons.erase(muons.begin()+iMu); continue; }
+    }
+}
+//----------------------------------------------------------
+void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR)
+{
+    // default procedure:
+    //  > if dR between electron and jet < J_E_DR:
+    //          --> remove the jet and keep the electron
+    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--) {
+        const Electron* e = electrons.at(iEl);
+        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
-            // if doing BjetOR procedure:
-            //  > if dR between electron and jet < J_E_DR:
-            //          --> if bjet: keep the jet, remove electron
-            //          --> if not bjet: remove the jet, keep the electron
-            // if not doing BjetOR procedure:
-            //  > if dR between electron and jet < J_E_DR:
-            //          --> remove the jet and keep the electron
-            if(doBjetOR()){
-                if(e->DeltaRy(*j) < J_E_DR){
-                    if(j->mv2c20 > JetSelector::mv2c20_80efficiency()) {
-                        electrons.erase(electrons.begin()+iEl);
-                        break; // loop electron no longer exists
-                    } else { jets.erase(jets.begin()+iJ); }
-                } // dR match
-            } // doBjetOR
-            else {
-                if(e->DeltaRy(*j) < J_E_DR) { jets.erase(jets.begin()+iJ); }
-            } // not doBjetOR
+            if(e->DeltaRy(*j) < dR) {
+                jets.erase(jets.begin()+iJ);
+            }
         } // iJ
     } // iEl
 
 }
-////////////////////////////////////////////
-// Remove electrons overlapping with jets
-//  E_J_DR = 0.4
-////////////////////////////////////////////
-void OverlapTools::e_j_overlap(ElectronVector& electrons, JetVector& jets)
+//----------------------------------------------------------
+void OverlapTools::e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR)
 {
-    if(electrons.size()==0 || jets.size()==0) return;
-    for(int iEl=electrons.size()-1; iEl>=0; iEl--){
+    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--){
         const Electron* e = electrons.at(iEl);
-        for(uint iJ=0; iJ<jets.size(); iJ++){
-       // for(int iJ=jets.size()-1; iJ>=0; iJ--){
+        for(size_t iJ=0; iJ<jets.size(); iJ++){
             const Jet* j = jets.at(iJ);
-            if(e->DeltaRy(*j)<E_J_DR) {
+            if(e->DeltaRy(*j) < dR) {
                 electrons.erase(electrons.begin()+iEl);
                 break;
             }
-            if(e->DeltaRy(*j) > E_J_DR) continue;
-            electrons.erase(electrons.begin()+iEl);
-            break; // move to next electron since iEl no longer exists!
-        } // iJ
-    } // iEl
+        } // for(iJ)
+    } // for(iEl)
 }
-////////////////////////////////////////////
-// Remove muons overlapping with jets
-//  M_J_DR = 0.4
-////////////////////////////////////////////
-void OverlapTools::m_j_overlap(MuonVector& muons, JetVector& jets)
+//----------------------------------------------------------
+void OverlapTools::m_j_overlap(MuonVector& muons, JetVector& jets, double dR)
 {
-    /////////////////////////
-    // update
-    /////////////////////////
-    if(muons.size()==0 || jets.size()==0) return;
-    for(int iMu=muons.size()-1; iMu>=0; iMu--){
+    for(size_t iMu=muons.size()-1; iMu>=0; iMu--){
         const Muon* mu = muons.at(iMu);
-        for(int iJ=jets.size()-1; iJ>=0; iJ--){
+        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
             int jet_nTrk = j->nTracks;
-            if(mu->DeltaRy(*j) > M_J_DR) continue;
+            if(mu->DeltaRy(*j) > dR) continue;
             if(jet_nTrk < 3) {
                 jets.erase(jets.begin() + iJ);
             }
@@ -311,66 +155,54 @@ void OverlapTools::m_j_overlap(MuonVector& muons, JetVector& jets)
                 muons.erase(muons.begin() + iMu);
                 break;
             }
-        } // iJ
-    } // iMu
+        } // for(iJ)
+    } // for(iMu)
 }
-
-////////////////////////////////////////////
-// Remove electrons and muons overlapping 
-// with one another
-//  E_M_DR = 0.01
-////////////////////////////////////////////
-void OverlapTools::e_m_overlap(ElectronVector& electrons, MuonVector& muons)
+//----------------------------------------------------------
+void OverlapTools::e_m_overlap(ElectronVector& electrons, MuonVector& muons, double dR)
 {
     int nEl = electrons.size();
     int nMu = muons.size();
-    if(nEl==0 || nMu==0) return;
-    
+
     static std::set<const Electron*> electronsToRemove;
     static std::set<const Muon*> muonsToRemove;
     electronsToRemove.clear();
     muonsToRemove.clear();
-    
+
     for(int iEl=0; iEl<nEl; iEl++){
         const Electron* e = electrons.at(iEl);
         for(int iMu=0; iMu<nMu; iMu++){
             const Muon* mu = muons.at(iMu);
-            if(e->DeltaRy(*mu) < E_M_DR){
+            if(e->DeltaRy(*mu) < dR){
                 electronsToRemove.insert(e);
                 muonsToRemove.insert(mu);
             } // dR match
         } // iMu
     } // iEl
-    
+
     // remove the flagged electrons
     if(electronsToRemove.size()){
         for(int iEl=nEl-1; iEl>=0; iEl--){
             if(electronsToRemove.find(electrons.at(iEl)) != electronsToRemove.end()){
                 electrons.erase(electrons.begin()+iEl);
-            } // found one
-        } // iEl
-    } // el2remove
-
+            }
+        }
+    }
     // remove the flagged muons
     if(muonsToRemove.size()){
         for(int iMu=nMu-1; iMu>=0; iMu--){
             if(muonsToRemove.find(muons.at(iMu)) != muonsToRemove.end()){
                 muons.erase(muons.begin()+iMu);
-            } // found one
-        } // iMu
-    } // mu2remove
+            }
+        }
+    }
 }
-    
-////////////////////////////////////////////
-// Remove (sub-lead) electron overlapping
-// with (lead) lepton
-//  E_E_DR = 0.05
-////////////////////////////////////////////
-void OverlapTools::e_e_overlap(ElectronVector& electrons)
+//----------------------------------------------------------
+void OverlapTools::e_e_overlap(ElectronVector& electrons, double dR)
 {
     int nEl=electrons.size();
     if(nEl<2) return;
-    
+
     // Find all possible e-e pairings
     static std::set<const Electron*> electronsToRemove;
     electronsToRemove.clear();
@@ -378,7 +210,7 @@ void OverlapTools::e_e_overlap(ElectronVector& electrons)
         const Electron* ei = electrons.at(iEl);
         for(int jEl=iEl+1; jEl<nEl; jEl++){
             const Electron* ej = electrons.at(jEl);
-            if(ei->DeltaRy(*ej) < E_E_DR){
+            if(ei->DeltaRy(*ej) < dR){
                 if(ei->Pt() < ej->Pt()){
                     electronsToRemove.insert(ei);
                     break; // ei no longer exists for looping!
@@ -388,7 +220,6 @@ void OverlapTools::e_e_overlap(ElectronVector& electrons)
             } // dR match
         } // jEl
     } // iEl
-    
     // remove the flagged electrons
     for(int iEl=nEl-1; iEl>=0; iEl--){
         if(electronsToRemove.find(electrons.at(iEl)) != electronsToRemove.end()){
@@ -396,15 +227,12 @@ void OverlapTools::e_e_overlap(ElectronVector& electrons)
         } // found one
     }
 }
-////////////////////////////////////////////
-// Remove muons overlapping with one another
-//  M_M_DR = 0.05
-////////////////////////////////////////////
-void OverlapTools::m_m_overlap(MuonVector& muons)
+//----------------------------------------------------------
+void OverlapTools::m_m_overlap(MuonVector& muons, double dR)
 {
     int nMu = muons.size();
     if(nMu < 2) return;
-    
+
     // if 2 muons overlap, flag both for removal
     static std::set<const Muon*> muonsToRemove;
     muonsToRemove.clear();
@@ -412,25 +240,22 @@ void OverlapTools::m_m_overlap(MuonVector& muons)
         const Muon* imu = muons.at(iMu);
         for(int jMu=iMu+1; jMu<nMu; jMu++){
             const Muon* jmu = muons.at(jMu);
-            if(imu->DeltaRy(*jmu) < M_M_DR){
+            if(imu->DeltaRy(*jmu) < dR){
                 muonsToRemove.insert(imu);
                 muonsToRemove.insert(jmu);
-            } // if OR
-        } // jMu
-    } // iMu
+            }
+        } // for(jMu)
+    } // for(iMu)
     // remove flagged muons
     for(int iMu=nMu-1; iMu>=0; iMu--){
         const Muon* mu = muons.at(iMu);
         if(muonsToRemove.find(mu) != muonsToRemove.end()) {
             muons.erase(muons.begin()+iMu);
-        } // remove
-    } // iMu
+        }
+    }
 }
-////////////////////////////////////////////
-// Remove taus overlapping with electrons
-//  T_E_DR = 0.2
-////////////////////////////////////////////
-void OverlapTools::t_e_overlap(TauVector& taus, ElectronVector& electrons)
+//----------------------------------------------------------
+void OverlapTools::t_e_overlap(TauVector& taus, ElectronVector& electrons, double dR)
 {
     int nTau = taus.size();
     int nEle = electrons.size();
@@ -439,18 +264,15 @@ void OverlapTools::t_e_overlap(TauVector& taus, ElectronVector& electrons)
         const Tau* tau = taus.at(iTau);
         for(int iEl=nEle-1; iEl>=0; iEl--){
             const Electron* e = electrons.at(iEl);
-            if(tau->DeltaRy(*e) < T_E_DR){
+            if(tau->DeltaRy(*e) < dR){
                 taus.erase(taus.begin()+iTau);
                 break; // loop tau doesn't exist anymore!
-            } // dR match
-        } // iEl
-    } // iTau
+            } // if(dR< )
+        } // for(iEl)
+    } // for(iTau)
 }
-////////////////////////////////////////////
-// Remove taus overlapping with muons
-//  T_M_DR = 0.2
-////////////////////////////////////////////
-void OverlapTools::t_m_overlap(TauVector& taus, MuonVector& muons)
+//----------------------------------------------------------
+void OverlapTools::t_m_overlap(TauVector& taus, MuonVector& muons, double dR)
 {
     int nTau = taus.size();
     int nMuo = muons.size();
@@ -459,18 +281,15 @@ void OverlapTools::t_m_overlap(TauVector& taus, MuonVector& muons)
         const Tau* tau = taus.at(iTau);
         for(int iMu=nMuo-1; iMu>=0; iMu--){
             const Muon* mu = muons.at(iMu);
-            if(tau->DeltaRy(*mu) < T_M_DR){
+            if(tau->DeltaRy(*mu) < dR){
                 taus.erase(taus.begin()+iTau);
                 break; // loop tau doesn't exist anymore!
-            } // dR match
-        } // iMu
-    } // iTau
+            } // if(dR< )
+        } // for(iMu)
+    } // for(iTau)
 }
-////////////////////////////////////////////
-// Remove jets overlapping with taus
-//  J_T_DR = 0.2
-////////////////////////////////////////////
-void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets)
+//----------------------------------------------------------
+void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets, double dR)
 {
     int nTau=taus.size();
     int nJet=jets.size();
@@ -479,26 +298,47 @@ void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets)
         const Jet* jet = jets.at(iJet);
         for(int iTau=nTau-1; iTau>=0; iTau--){
             const Tau* tau = taus.at(iTau);
-            if(tau->DeltaRy(*jet) < J_T_DR){
+            if(tau->DeltaRy(*jet) < dR){
                 jets.erase(jets.begin()+iJet);
                 break; // loop jet doesn't exist anymore!
-            } // dR match
-        } // iTau
-    } // iJet
+            } // if(dR< )
+        } // for(iTau)
+    } // for(iJet)
 }
-
-
-// ------------------------------------------------------------------------------ //
-void OverlapTools::check()
+//----------------------------------------------------------
+// begin OverlapTools_SS3L
+//----------------------------------------------------------
+void OverlapTools_SS3L::performOverlap(ElectronVector& electrons, MuonVector& muons,
+                                       TauVector& taus, JetVector& jets)
 {
-    if(m_analysis == AnalysisType::kUnknown) {
-        string error = "OverlapTools::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for OverlapTools. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for OverlapTools for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    return;
+    j_e_overlap(electrons, jets, 0.2);
+    e_j_overlap(electrons, jets, 0.4);
+    m_j_overlap(muons, jets, 0.2); // default 0.2
+    e_m_overlap(electrons, muons, 0.01);
+    e_e_overlap(electrons, 0.05);
 }
-
+//----------------------------------------------------------
+void OverlapTools_SS3L::j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR)
+{
+    // doing BjetOR procedure:
+    //  > if electron close to jet:
+    //       --> if bjet: keep the jet, remove electron
+    //       --> if not bjet: remove the jet, keep the electron
+    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--) {
+        const Electron* e = electrons.at(iEl);
+        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
+            const Jet* j = jets.at(iJ);
+            if(e->DeltaRy(*j) < 0.2){ // was J_E_DR
+                bool isBjet = (j->mv2c20 > JetSelector::mv2c20_80efficiency());
+                if(isBjet) {
+                    electrons.erase(electrons.begin()+iEl);
+                    break; // loop electron no longer exists
+                } else {
+                    jets.erase(jets.begin()+iJ);
+                }
+            } // if(dR<)
+        } // for(iJ)
+    } // for(iEl)
+}
+//----------------------------------------------------------
 }; // namespace Susy

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -311,16 +311,6 @@ void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets, double dR)
 //----------------------------------------------------------
 // begin OverlapTools_SS3L
 //----------------------------------------------------------
-void OverlapTools_SS3L::performOverlap(ElectronVector& electrons, MuonVector& muons,
-                                       TauVector& taus, JetVector& jets)
-{
-    j_e_overlap(electrons, jets, 0.2);
-    e_j_overlap(electrons, jets, 0.4);
-    m_j_overlap(muons, jets, 0.2); // default 0.4
-    e_m_overlap(electrons, muons, 0.01);
-    e_e_overlap(electrons, 0.05);
-}
-//----------------------------------------------------------
 void OverlapTools_SS3L::j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR)
 {
     // doing BjetOR procedure:

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -322,7 +322,7 @@ void OverlapTools_SS3L::j_e_overlap(ElectronVector& electrons, JetVector& jets, 
         const Electron* e = electrons.at(iEl);
         for(int iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
-            if(e->DeltaRy(*j) < 0.2){ // was J_E_DR
+            if(e->DeltaRy(*j) < dR){
                 bool isBjet = (j->mv2c20 > JetSelector::mv2c20_80efficiency());
                 if(isBjet) {
                     electrons.erase(electrons.begin()+iEl);

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -114,9 +114,10 @@ void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets, doubl
     // default procedure:
     //  > if dR between electron and jet < J_E_DR:
     //          --> remove the jet and keep the electron
-    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--) {
+    if(electrons.size()==0 || jets.size()==0) return;
+    for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
         const Electron* e = electrons.at(iEl);
-        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
+        for(int iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
             if(e->DeltaRy(*j) < dR) {
                 jets.erase(jets.begin()+iJ);
@@ -128,7 +129,8 @@ void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets, doubl
 //----------------------------------------------------------
 void OverlapTools::e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR)
 {
-    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--){
+    if(electrons.size()==0 || jets.size()==0) return;
+    for(int iEl=electrons.size()-1; iEl>=0; iEl--){
         const Electron* e = electrons.at(iEl);
         for(size_t iJ=0; iJ<jets.size(); iJ++){
             const Jet* j = jets.at(iJ);
@@ -142,9 +144,10 @@ void OverlapTools::e_j_overlap(ElectronVector& electrons, JetVector& jets, doubl
 //----------------------------------------------------------
 void OverlapTools::m_j_overlap(MuonVector& muons, JetVector& jets, double dR)
 {
-    for(size_t iMu=muons.size()-1; iMu>=0; iMu--){
+    if(muons.size()==0 || jets.size()==0) return;
+    for(int iMu=muons.size()-1; iMu>=0; iMu--){
         const Muon* mu = muons.at(iMu);
-        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
+        for(int iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
             int jet_nTrk = j->nTracks;
             if(mu->DeltaRy(*j) > dR) continue;
@@ -163,12 +166,12 @@ void OverlapTools::e_m_overlap(ElectronVector& electrons, MuonVector& muons, dou
 {
     int nEl = electrons.size();
     int nMu = muons.size();
+    if(nEl==0 || nMu==0) return;
 
     static std::set<const Electron*> electronsToRemove;
     static std::set<const Muon*> muonsToRemove;
     electronsToRemove.clear();
     muonsToRemove.clear();
-
     for(int iEl=0; iEl<nEl; iEl++){
         const Electron* e = electrons.at(iEl);
         for(int iMu=0; iMu<nMu; iMu++){
@@ -313,7 +316,7 @@ void OverlapTools_SS3L::performOverlap(ElectronVector& electrons, MuonVector& mu
 {
     j_e_overlap(electrons, jets, 0.2);
     e_j_overlap(electrons, jets, 0.4);
-    m_j_overlap(muons, jets, 0.2); // default 0.2
+    m_j_overlap(muons, jets, 0.2); // default 0.4
     e_m_overlap(electrons, muons, 0.01);
     e_e_overlap(electrons, 0.05);
 }
@@ -324,9 +327,10 @@ void OverlapTools_SS3L::j_e_overlap(ElectronVector& electrons, JetVector& jets, 
     //  > if electron close to jet:
     //       --> if bjet: keep the jet, remove electron
     //       --> if not bjet: remove the jet, keep the electron
-    for(size_t iEl=electrons.size()-1; iEl>=0; iEl--) {
+    if(electrons.size()==0 || jets.size()==0) return;
+    for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
         const Electron* e = electrons.at(iEl);
-        for(size_t iJ=jets.size()-1; iJ>=0; iJ--){
+        for(int iJ=jets.size()-1; iJ>=0; iJ--){
             const Jet* j = jets.at(iJ);
             if(e->DeltaRy(*j) < 0.2){ // was J_E_DR
                 bool isBjet = (j->mv2c20 > JetSelector::mv2c20_80efficiency());

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -1,5 +1,6 @@
 #include "SusyNtuple/OverlapTools.h"
 #include "SusyNtuple/SusyNt.h"
+#include "SusyNtuple/JetSelector.h"
 
 #include <set>
 #include <iostream>
@@ -252,7 +253,7 @@ void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets)
             //          --> remove the jet and keep the electron
             if(doBjetOR()){
                 if(e->DeltaRy(*j) < J_E_DR){
-                    if(j->mv2c20 > -0.5517) {
+                    if(j->mv2c20 > JetSelector::mv2c20_80efficiency()) {
                         electrons.erase(electrons.begin()+iEl);
                         break; // loop electron no longer exists
                     } else { jets.erase(jets.begin()+iJ); }

--- a/Root/Susy2LepCutflow.cxx
+++ b/Root/Susy2LepCutflow.cxx
@@ -2,6 +2,7 @@
 #include "TCanvas.h"
 #include "SusyNtuple/Susy2LepCutflow.h"
 #include "SusyNtuple/KinematicTools.h"
+#include "SusyNtuple/JetSelector.h"
 
 using namespace std;
 using namespace Susy;
@@ -501,7 +502,7 @@ bool Susy2LepCutflow::passbJetVeto(const JetVector& jets)
   bool hasbjet = false;
   for(uint i=0; i<jets.size(); ++i){
     const Jet* jet = jets.at(i);
-    if( jet->mv2c20 > -0.4434 )  // this is a dummy BJet tag
+    if( jet->mv2c20 > JetSelector::mv2c20_77efficiency())  // this is a dummy BJet tag
         hasbjet = true;
     break;
   }

--- a/Root/SusyNtAna.cxx
+++ b/Root/SusyNtAna.cxx
@@ -112,10 +112,10 @@ void SusyNtAna::Terminate()
 /*--------------------------------------------------------------------------------*/
 // Load Event list of run/event to process. Use to debug events
 /*--------------------------------------------------------------------------------*/
-void SusyNtAna::loadEventList()
+void SusyNtAna::loadEventList(const std::string filename)
 {
   int run, event;
-  FILE* eventsFile=fopen("debugEvents.txt","r");
+  FILE* eventsFile=fopen(filename.c_str(),"r");
   int nEvtDbg=0;
   while(fscanf(eventsFile,"%i %i \n",&run, &event) != EOF){
     cout << "Adding run-event " << run << " " << event << endl; 

--- a/Root/SusyNtAna.cxx
+++ b/Root/SusyNtAna.cxx
@@ -252,11 +252,10 @@ void SusyNtAna::selectObjects(SusyNtSys sys, TauId signalTauID)
   m_nttools.getBaselineObjects(m_preElectrons, m_preMuons, m_preJets, m_preTaus,
                                m_baseElectrons, m_baseMuons, m_baseJets, m_baseTaus);
   ///////////////////////////////////////
-  // do OR for baseline
+  // do OR 
   ///////////////////////////////////////
-  if(!m_nttools.m_overlapTool.useSignalLeptons()) {
-    m_nttools.m_overlapTool.performOverlap(m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets);
-  }
+  m_nttools.overlapTool().performOverlap(m_baseElectrons, m_baseMuons, m_baseTaus, m_baseJets);
+
   ///////////////////////////////////////
   // SFOS removal
   ///////////////////////////////////////
@@ -269,12 +268,6 @@ void SusyNtAna::selectObjects(SusyNtSys sys, TauId signalTauID)
   ///////////////////////////////////////
   m_nttools.getSignalObjects(m_baseElectrons, m_baseMuons, m_baseJets, m_baseTaus,
                               m_signalElectrons, m_signalMuons, m_signalJets, m_signalTaus, signalTauID);
-  ///////////////////////////////////////
-  // do OR for signal
-  ///////////////////////////////////////
-  if(m_nttools.m_overlapTool.useSignalLeptons()) {
-    m_nttools.m_overlapTool.performOverlap(m_signalElectrons, m_signalMuons, m_signalTaus, m_signalJets);
-  }
 
   ///////////////////////////////////////
   // Build Lepton vectors

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -233,7 +233,7 @@ ElectronVector SusyNtTools::getBaselineElectrons(const ElectronVector& preElecs)
     ElectronVector elecs;
     for (uint ie = 0; ie < preElecs.size(); ++ie) {
         Electron* e = preElecs.at(ie);
-        if(electronSelector().isBaselineElectron(e)){
+        if(electronSelector().isBaseline(e)){
             elecs.push_back(e);
         }
     } // ie
@@ -262,7 +262,7 @@ MuonVector SusyNtTools::getBaselineMuons(const MuonVector& preMuons)
     MuonVector baseMuons;
     for (uint im = 0; im < preMuons.size(); ++im) {
         Muon* mu = preMuons.at(im);
-        if(muonSelector().isBaselineMuon(mu)){
+        if(muonSelector().isBaseline(mu)){
             baseMuons.push_back(mu);
         }
     } // im
@@ -277,7 +277,7 @@ TauVector SusyNtTools::getBaselineTaus(const TauVector& preTaus)
     TauVector baseTaus;
     for (uint iTau = 0; iTau < preTaus.size(); iTau++) {
         Tau* tau = preTaus.at(iTau);
-        if(tauSelector().isBaselineTau(tau)){
+        if(tauSelector().isBaseline(tau)){
             baseTaus.push_back(tau);
         }
     } // iTau
@@ -320,7 +320,7 @@ JetVector SusyNtTools::getBaselineJets(const JetVector& preJets)
     JetVector baseJets;
     for (uint ij = 0; ij < preJets.size(); ++ij) {
         Jet* j = preJets.at(ij);
-        if(jetSelector().isBaselineJet(j)) {
+        if(jetSelector().isBaseline(j)) {
             baseJets.push_back(j);
         }
     } // ij
@@ -337,7 +337,7 @@ ElectronVector SusyNtTools::getSignalElectrons(const ElectronVector& baseElecs)
     ElectronVector sigElecs;
     for (uint ie = 0; ie < baseElecs.size(); ++ie) {
         Electron* e = baseElecs.at(ie);
-        if (electronSelector().isSignalElectron(e)){
+        if (electronSelector().isSignal(e)){
             sigElecs.push_back(e);
         }
     }
@@ -352,7 +352,7 @@ MuonVector SusyNtTools::getSignalMuons(const MuonVector& baseMuons)
     MuonVector sigMuons;
     for (uint im = 0; im < baseMuons.size(); ++im) {
         Muon* mu = baseMuons.at(im);
-        if (muonSelector().isSignalMuon(mu)){
+        if (muonSelector().isSignal(mu)){
             sigMuons.push_back(mu);
         }
     }
@@ -368,7 +368,7 @@ TauVector SusyNtTools::getSignalTaus(const TauVector& baseTaus)
     for (uint iTau = 0; iTau < baseTaus.size(); iTau++) {
         Tau* tau = baseTaus[iTau];
 
-        if(tauSelector().isSignalTau(tau)) {
+        if(tauSelector().isSignal(tau)) {
             sigTaus.push_back(tau);
         }
     } // iTau
@@ -384,7 +384,7 @@ JetVector SusyNtTools::getSignalJets(const JetVector& baseJets)
     JetVector sigJets;
     for(uint ij=0; ij<baseJets.size(); ++ij){
         Jet* j = baseJets.at(ij);
-        if(jetSelector().isSignalJet(j)) {
+        if(jetSelector().isSignal(j)) {
             sigJets.push_back(j);
         }
     }
@@ -461,27 +461,26 @@ TrackMet* SusyNtTools::getTrackMet(SusyNtObject* susyNt, SusyNtSys sys)//, bool 
 /*--------------------------------------------------------------------------------*/
 // Check if Lepton is Signal Lepton
 /*--------------------------------------------------------------------------------*/
-bool SusyNtTools::isSignalLepton(const Lepton* l)
+bool SusyNtTools::isSignal(const Lepton* l)
 {
-    if(l->isEle()) return electronSelector().isSignalElectron((Electron*)l);
-    else           return muonSelector().isSignalMuon((Muon*)l);
+    if(l->isEle()) return electronSelector().isSignal((Electron*)l);
+    else           return muonSelector().isSignal((Muon*)l);
 };
 /*--------------------------------------------------------------------------------*/
-bool SusyNtTools::isSignalElectron(const Electron* e)
+bool SusyNtTools::isSignal(const Electron* e)
 {
-    return electronSelector().isSignalElectron(e);
+    return electronSelector().isSignal(e);
 }
 /*--------------------------------------------------------------------------------*/
-bool SusyNtTools::isSignalMuon(const Muon* m)
+bool SusyNtTools::isSignal(const Muon* m)
 {
-    return muonSelector().isSignalMuon(m);
+    return muonSelector().isSignal(m);
 }
 
 /*--------------------------------------------------------------------------------*/
-bool SusyNtTools::isSignalTau(const Tau* tau)
+bool SusyNtTools::isSignal(const Tau* tau)
 {
-    // At the moment, signal taus only use additional BDT selection
-    return tauSelector().isSignalTau(tau);
+    return tauSelector().isSignal(tau);
 }
 /*--------------------------------------------------------------------------------*/
 int SusyNtTools::numberOfCLJets(const JetVector& jets)
@@ -513,7 +512,7 @@ JetVector SusyNtTools::getBJets(const JetVector& jets)
 {
     JetVector bJets;
     for(auto jet : jets) {
-        if (jetSelector().isCentralBJet(jet))
+        if (jetSelector().isCentralB(jet))
             bJets.push_back(jet);
     }
     return bJets;

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -52,7 +52,7 @@ void SusyNtTools::setAnaType(AnalysisType a, bool verbose)
     // OverlapTool
     // propagate isolation requirements
     m_overlapTool.setElectronIsolation(electronSelector().signalIsolation());
-    m_overlapTool.setMuonIsolation(muonSelector().signalMuonIsolation());
+    m_overlapTool.setMuonIsolation(muonSelector().signalIsolation());
     // propagate OR loose b-tag WP
     m_overlapTool.setORBtagEff(jetSelector().overlapRemovalBtagEffWP());
     // now setAnalysis

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -44,11 +44,15 @@ void SusyNtTools::setAnaType(AnalysisType a, bool verbose)
 {
     if(m_electronSelector) delete m_electronSelector;
     m_electronSelector = ElectronSelector::build(a, verbose);
+
     if(m_muonSelector) delete m_muonSelector;
     m_muonSelector = MuonSelector::build(a, verbose);
-    m_tauSelector.setAnalysis(a);
     if(m_jetSelector) delete m_jetSelector;
     m_jetSelector = JetSelector::build(a, verbose);
+
+    if(m_tauSelector) delete m_tauSelector;
+    m_tauSelector = TauSelector::build(a, verbose);
+
     // OverlapTool
     // propagate isolation requirements
     m_overlapTool.setElectronIsolation(electronSelector().signalIsolation());
@@ -177,7 +181,7 @@ void SusyNtTools::getSignalObjects(const ElectronVector& baseElectrons, const Mu
 {
     signalElectrons = getSignalElectrons(baseElectrons);
     signalMuons     = getSignalMuons(baseMuons);
-    signalTaus      = getSignalTaus(baseTaus, sigTauId, sigTauId, sigTauId); // jetBDT, eleBDT, muoBDT
+    signalTaus      = getSignalTaus(baseTaus);
     signalJets      = getSignalJets(baseJets);
 }
 /*--------------------------------------------------------------------------------*/
@@ -273,7 +277,7 @@ TauVector SusyNtTools::getBaselineTaus(const TauVector& preTaus)
     TauVector baseTaus;
     for (uint iTau = 0; iTau < preTaus.size(); iTau++) {
         Tau* tau = preTaus.at(iTau);
-        if(m_tauSelector.isBaselineTau(tau)){
+        if(tauSelector().isBaselineTau(tau)){
             baseTaus.push_back(tau);
         }
     } // iTau
@@ -358,13 +362,13 @@ MuonVector SusyNtTools::getSignalMuons(const MuonVector& baseMuons)
     return sigMuons;
 }
 /*--------------------------------------------------------------------------------*/
-TauVector SusyNtTools::getSignalTaus(const TauVector& baseTaus, TauId tauJetID, TauId tauEleID, TauId tauMuoID)
+TauVector SusyNtTools::getSignalTaus(const TauVector& baseTaus)
 {
     TauVector sigTaus;
     for (uint iTau = 0; iTau < baseTaus.size(); iTau++) {
         Tau* tau = baseTaus[iTau];
 
-        if(m_tauSelector.isSignalTau(tau, tauJetID, tauEleID, tauMuoID)) {
+        if(tauSelector().isSignalTau(tau)) {
             sigTaus.push_back(tau);
         }
     } // iTau
@@ -474,10 +478,10 @@ bool SusyNtTools::isSignalMuon(const Muon* m)
 }
 
 /*--------------------------------------------------------------------------------*/
-bool SusyNtTools::isSignalTau(const Tau* tau, TauId tauJetID, TauId tauEleID, TauId tauMuoID)
+bool SusyNtTools::isSignalTau(const Tau* tau)
 {
     // At the moment, signal taus only use additional BDT selection
-    return m_tauSelector.isSignalTau(tau, tauJetID, tauEleID, tauMuoID);
+    return tauSelector().isSignalTau(tau);
 }
 /*--------------------------------------------------------------------------------*/
 int SusyNtTools::numberOfCLJets(const JetVector& jets)

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -27,6 +27,7 @@ using namespace Susy;
 SusyNtTools::SusyNtTools() :
     m_electronSelector(nullptr),
     m_muonSelector(nullptr),
+    m_tauSelector(nullptr),
     m_jetSelector(nullptr),
     m_overlapTool(nullptr),
     m_anaType(AnalysisType::kUnknown),

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -28,6 +28,7 @@ SusyNtTools::SusyNtTools() :
     m_electronSelector(nullptr),
     m_muonSelector(nullptr),
     m_jetSelector(nullptr),
+    m_overlapTool(nullptr),
     m_anaType(AnalysisType::kUnknown),
     m_doSFOS(false)
 {
@@ -38,6 +39,7 @@ SusyNtTools::~SusyNtTools()
     if(m_electronSelector) { delete m_electronSelector; m_electronSelector = nullptr; }
     if(m_muonSelector) { delete m_muonSelector; m_muonSelector = nullptr; }
     if(m_jetSelector) { delete m_jetSelector; m_jetSelector = nullptr; }
+    if(m_overlapTool) {delete m_overlapTool; m_overlapTool = nullptr; }
 }
 //----------------------------------------------------------
 void SusyNtTools::setAnaType(AnalysisType a, bool verbose)
@@ -53,14 +55,11 @@ void SusyNtTools::setAnaType(AnalysisType a, bool verbose)
     if(m_tauSelector) delete m_tauSelector;
     m_tauSelector = TauSelector::build(a, verbose);
 
-    // OverlapTool
-    // propagate isolation requirements
-    m_overlapTool.setElectronIsolation(electronSelector().signalIsolation());
-    m_overlapTool.setMuonIsolation(muonSelector().signalIsolation());
-    // propagate OR loose b-tag WP
-    m_overlapTool.setORBtagEff(jetSelector().overlapRemovalBtagEffWP());
-    // now setAnalysis
-    m_overlapTool.setAnalysis(a);
+    if(m_overlapTool) delete m_overlapTool;
+    m_overlapTool = OverlapTools::build(a, verbose);
+    // propagate isolation requirements, needed only for removeNonisolatedLeptons()
+    m_overlapTool->setElectronIsolation(electronSelector().signalIsolation());
+    m_overlapTool->setMuonIsolation(muonSelector().signalIsolation());
 
     // set whether to perform SFOS removal on baseline objects
     setSFOSRemoval(a);

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -33,7 +33,7 @@ TauSelector::TauSelector():
 {
 }
 //----------------------------------------------------------
-bool TauSelector::isBaselineTau(const Tau& tau)
+bool TauSelector::isBaseline(const Tau& tau)
 {
     // \todo update with Run2 recommendations
     // DG-2015-09-22
@@ -44,9 +44,9 @@ bool TauSelector::isBaselineTau(const Tau& tau)
             passBdtBaseline(tau));
 }
 //----------------------------------------------------------
-bool TauSelector::isSignalTau(const Tau& tau)
+bool TauSelector::isSignal(const Tau& tau)
 {
-    return (isBaselineTau(tau) &&
+    return (isBaseline(tau) &&
             passBdtSignal(tau) );
 }
 //----------------------------------------------------------

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -1,11 +1,8 @@
 #include "SusyNtuple/TauSelector.h"
-#include "SusyNtuple/SusyNt.h"
-#include "SusyNtuple/TauId.h"
+#include "SusyNtuple/Tau.h"
 
 #include <iostream>
 
-using Susy::TauSelector;
-using Susy::Tau;
 using Susy::NtSys::SusyNtSys;
 using std::cout;
 using std::endl;
@@ -13,306 +10,81 @@ using std::string;
 
 namespace Susy {
 
-// -------------------------------------------------------------------------------------------- //
-// Constructor
-// -------------------------------------------------------------------------------------------- //
-TauSelector::TauSelector() :
-    //////////////////////////
-    // default selection
-    //////////////////////////
-    TAU_MIN_PT_BASELINE(20.0),
-    TAU_MIN_PT_SIGNAL(20.0),
-    //////////////////////////
-    m_systematic(NtSys::NOM),
-    m_analysis(AnalysisType::kUnknown),
-    m_signalTauId(TauId::Invalid),
-    m_tauEleBaseId(TauId::Invalid),
-    m_tauJetBaseId(TauId::Invalid),
-    m_tauMuoBaseId(TauId::Invalid),
-    m_tauEleId(TauId::Invalid),
-    m_tauJetId(TauId::Invalid),
-    m_tauMuoId(TauId::Invalid),
-    m_2lep(false),
-    m_3lep(false),
-    m_2lepWH(false),
-    m_SS3L(false),
-    m_stop2l(false),
+//----------------------------------------------------------
+TauSelector* TauSelector::build(const AnalysisType &a, bool verbose)
+{
+    TauSelector *selector;
+    switch(a) {
+    case AnalysisType::Ana_2Lep   : selector = new TauSelector_2Lep(); break;
+    case AnalysisType::Ana_3Lep   : selector = new TauSelector_3Lep(); break;
+    case AnalysisType::Ana_2LepWH : selector = new TauSelector_2LepWH(); break;
+    case AnalysisType::Ana_SS3L   : selector = new TauSelector_SS3L(); break;
+    case AnalysisType::Ana_Stop2L : selector = new TauSelector_Stop2L(); break;
+    default:
+        cout<<"TauSelector::build(): unknown analysis type '"<<AnalysisType2str(a)<<"'"
+            <<" returning vanilla TauSelector"<<endl;
+        selector = new TauSelector();
+    }
+    return selector;
+}
+//----------------------------------------------------------
+TauSelector::TauSelector():
     m_verbose(false)
 {
 }
-// -------------------------------------------------------------------------------------------- //
-TauSelector& TauSelector::setAnalysis(const AnalysisType &a)
-{
-
-    //////////////////////////////////////
-    // Set analysis-specific cuts
-    //////////////////////////////////////
-
-    //////////////////////////////////////
-    // 2L-ANALYSIS
-    //////////////////////////////////////
-    if( a == AnalysisType::Ana_2Lep ) {
-        m_2lep = true;
-
-        m_signalTauId = TauId::Medium;
-
-        m_tauEleBaseId = TauId::Loose;
-        m_tauJetBaseId = TauId::Medium;
-        m_tauMuoBaseId = TauId::Medium;
-
-        m_tauEleId = TauId::Loose;
-        m_tauJetId = TauId::Medium;
-        m_tauMuoId = TauId::Medium;
-
-    } 
-    //////////////////////////////////////
-    // 3L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_3Lep ) {
-        m_3lep = true;
-
-        m_signalTauId = TauId::Medium;
-
-        m_tauEleBaseId = TauId::Loose;
-        m_tauJetBaseId = TauId::Medium;
-        m_tauMuoBaseId = TauId::Medium;
-
-        m_tauEleId = TauId::Loose;
-        m_tauJetId = TauId::Medium;
-        m_tauMuoId = TauId::Medium;
-
-    }
-    //////////////////////////////////////
-    // WH-ANALYSIS
-    //////////////////////////////////////
-    else if( a== AnalysisType::Ana_2LepWH ) {
-        m_2lepWH = true;
-
-        m_signalTauId = TauId::Medium;
-
-        m_tauEleBaseId = TauId::Loose;
-        m_tauJetBaseId = TauId::Medium;
-        m_tauMuoBaseId = TauId::Medium;
-
-        m_tauEleId = TauId::Loose;
-        m_tauJetId = TauId::Medium;
-        m_tauMuoId = TauId::Medium;
-
-    }
-    //////////////////////////////////////
-    // SS3L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_SS3L ) {
-        m_SS3L = true;
-
-        m_signalTauId = TauId::Medium;
-
-        m_tauEleBaseId = TauId::Loose;
-        m_tauJetBaseId = TauId::Medium;
-        m_tauMuoBaseId = TauId::Medium;
-
-        m_tauEleId = TauId::Loose;
-        m_tauJetId = TauId::Medium;
-        m_tauMuoId = TauId::Medium;
-
-    }
-    //////////////////////////////////////
-    // STOP2L-ANALYSIS
-    //////////////////////////////////////
-    else if( a == AnalysisType::Ana_Stop2L ) {
-        m_stop2l = true;
-
-        m_signalTauId = TauId::Medium;
-
-        m_tauEleBaseId = TauId::Loose;
-        m_tauJetBaseId = TauId::Medium;
-        m_tauMuoBaseId = TauId::Medium;
-
-        m_tauEleId = TauId::Loose;
-        m_tauJetId = TauId::Medium;
-        m_tauMuoId = TauId::Medium;
-
-    }
-    //////////////////////////////////////
-    // Didn't set AnalysisType
-    //////////////////////////////////////
-    else if( a == AnalysisType::kUnknown ) {
-        string error = "TauSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for TauSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for TauSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    //////////////////////////////////////
-    // Gone fishin'
-    //////////////////////////////////////
-    else {
-        string error = "TauSelector::setAnalysis error: ";
-        cout << error << "TauSelector is not configured for the AnalysisType (" << AnalysisType2str(a) << ")  provided in " << endl;
-        cout << error << "'setAnalysis'! Be sure that your AnalysisType is provided for in SusyNtuple/AnalysisType.h" << endl;
-        cout << error << "and that you provide the necessary requirements for your analysis in 'setAnalysis'." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-
-    m_analysis = a;
-
-    if(m_verbose)
-        cout << "TauSelector    Configured tau selection for AnalysisType " << AnalysisType2str(m_analysis) << endl;
-
-    return *this;
-}
-// ---------------------------------------------------------
-TauSelector& TauSelector::setSystematic(const NtSys::SusyNtSys &s)
-{
-    m_systematic = s;
-    return *this;
-}
-
-// ---------------------------------------------------------
-bool TauSelector::isBaselineTau(const Tau* tau)
-{
-    TauSelector::check();
-    return TauSelector::isBaselineTau(*tau);
-}
+//----------------------------------------------------------
 bool TauSelector::isBaselineTau(const Tau& tau)
 {
-    /////////////////////////
-    // pT requirement
-    /////////////////////////
-    if(tau.Pt() < TAU_MIN_PT_BASELINE) return false;
+    // \todo update with Run2 recommendations
+    // DG-2015-09-22
+    // the current implementation is a relic from Run1.
+    // https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Taus
 
-    /////////////////////////
-    // BDT requirement
-    /////////////////////////
-    if(!tauPassBDT(tau, false)) return false;
-
-    return true;
+    return (tau.Pt() > 20.0 &&
+            passBdtBaseline(tau));
 }
-
-// ---------------------------------------------------------
-bool TauSelector::isSignalTau(const Tau* tau, const TauId& jetId, const TauId& eleId, const TauId& muoId)
+//----------------------------------------------------------
+bool TauSelector::isSignalTau(const Tau& tau)
 {
-    TauSelector::check();
-    return TauSelector::isSignalTau(*tau, jetId, eleId, muoId);
+    return (isBaselineTau(tau) &&
+            passBdtSignal(tau) );
 }
-bool TauSelector::isSignalTau(const Tau& tau, const TauId& jetId, const TauId& eleId, const TauId& muoId)
+//----------------------------------------------------------
+bool TauSelector::passBdtBaseline(const Tau& tau)
 {
-    return TauSelector::isTauBDT(tau, jetId, eleId, muoId);
+    bool fail_ele = (tau.nTrack == 1 && tau.eleBDTLoose != 0);
+    return (tau.jetBDTSigMedium == 1 &&
+            tau.muonVeto == 0 &&
+            !fail_ele );
 }
-// ---------------------------------------------------------
-bool TauSelector::isTauBDT(const Tau* tau, const TauId& jetId, const TauId& eleId, const TauId& muoId)
+//----------------------------------------------------------
+bool TauSelector::passBdtSignal(const Tau& tau)
 {
-    return TauSelector::isTauBDT(*tau, jetId, eleId, muoId);
+    bool fail_ele = (tau.nTrack == 1 && tau.eleBDTLoose != 0);
+    return (tau.jetBDTSigMedium == 1 &&
+            tau.muonVeto == 0 &&
+            !fail_ele);
 }
-bool TauSelector::isTauBDT(const Tau& tau, const TauId& jetId, const TauId& eleId, const TauId& muoId)
-{
-    
-    /////////////////////////
-    // Jet BDT cut
-    /////////////////////////
-    if(jetId == TauId::Loose){
-        if(tau.jetBDTSigLoose != 1) return false;
-    }
-    else if(jetId == TauId::Medium){
-        if(tau.jetBDTSigMedium != 1 ) return false;
-    }
-    else if(jetId == TauId::Tight){
-        if(tau.jetBDTSigTight != 1) return false;
-    }
+//----------------------------------------------------------
+// begin JetSelector_2Lep
+//----------------------------------------------------------
 
-    /////////////////////////
-    // Electron BDT cut
-    /////////////////////////
-    if(eleId == TauId::Loose){
-        if(tau.nTrack == 1 && tau.eleBDTLoose != 0) return false;
-    }
-    else if(eleId == TauId::Medium){
-        if(tau.nTrack == 1 && tau.eleBDTMedium != 0) return false;
-    }
-    else if(eleId == TauId::Tight){
-        if(tau.nTrack == 1 && tau.eleBDTTight != 0) return false;
-    }
+//----------------------------------------------------------
+// begin JetSelector_3Lep
+//----------------------------------------------------------
 
-    /////////////////////////
-    // Muon veto
-    /////////////////////////
-    if(muoId >= TauId::Medium) {
-        if(tau.muonVeto != 0) return false;
-    }
+//----------------------------------------------------------
+// begin JetSelector_2LepWH
+//----------------------------------------------------------
 
-    return true;
-}
+//----------------------------------------------------------
+// begin JetSelector_SS3L
+//----------------------------------------------------------
 
-//// ---------------------------------------------------------
-//bool TauSelector::isSignalTau(const Tau* tau)
-//{
-//    TauSelector::check();
-//    return TauSelector::isSignalTau(*tau);
-//}
-//bool TauSelector::isSignalTau(const Tau& tau)
-//{
-//    ////////////////////////////
-//    // BDT requirement
-//    ////////////////////////////
-//    if(!tauPassBDT(tau, true)) return false;
-//
-//    return true;
-//}
-// ---------------------------------------------------------
-bool TauSelector::tauPassBDT(const Tau& tau, bool isSignal)
-{
-    TauId jetId = isSignal ? m_tauJetId : m_tauJetBaseId;
-    TauId eleId = isSignal ? m_tauEleId : m_tauEleBaseId;
-    TauId muoId = isSignal ? m_tauMuoId : m_tauMuoBaseId; 
+//----------------------------------------------------------
+// begin JetSelector_Stop2L
+//----------------------------------------------------------
 
-    /////////////////////////
-    // Jet BDT cut
-    /////////////////////////
-    if(jetId == TauId::Loose){
-        if(tau.jetBDTSigLoose != 1) return false;
-    }
-    else if(jetId == TauId::Medium){
-        if(tau.jetBDTSigMedium != 1 ) return false;
-    }
-    else if(jetId == TauId::Tight){
-        if(tau.jetBDTSigTight != 1) return false;
-    }
-
-    /////////////////////////
-    // Electron BDT cut
-    /////////////////////////
-    if(eleId == TauId::Loose){
-        if(tau.nTrack == 1 && tau.eleBDTLoose != 0) return false;
-    }
-    else if(eleId == TauId::Medium){
-        if(tau.nTrack == 1 && tau.eleBDTMedium != 0) return false;
-    }
-    else if(eleId == TauId::Tight){
-        if(tau.nTrack == 1 && tau.eleBDTTight != 0) return false;
-    }
-
-    /////////////////////////
-    // Muon veto
-    /////////////////////////
-    if(muoId >= TauId::Medium) {
-        if(tau.muonVeto != 0) return false;
-    }
-
-    return true;
-}
-    
-/* --------------------------------------------------------------------------------------------- */
-void TauSelector::check()
-{
-    if(m_analysis == AnalysisType::kUnknown) {
-        string error = "TauSelector::setAnalysis error: ";
-        cout << error << "The AnalysisType has not been set for TauSelector. Check that you properly call" << endl;
-        cout << error << "'setAnalysis' for TauSelector for your analysis." << endl;
-        cout << error << ">>> Exiting." << endl;
-        exit(1);
-    }
-    return;
-}
-/* --------------------------------------------------------------------------------------------- */
+//----------------------------------------------------------
 } // namespace Susy
+

--- a/SusyNtuple/ElectronSelector.h
+++ b/SusyNtuple/ElectronSelector.h
@@ -2,7 +2,6 @@
 #ifndef SUSYNTUPLE_ELECTRONSELECTOR_H
 #define SUSYNTUPLE_ELECTRONSELECTOR_H
 
-#include "SusyNtuple/SusyDefs.h"
 #include "SusyNtuple/SusyNtSys.h"
 #include "SusyNtuple/AnalysisType.h"
 #include "SusyNtuple/ElectronId.h"
@@ -10,112 +9,123 @@
 
 
 namespace Susy {
+class Electron;
 
+/// A class to select electrons
+/**
+   The generic ElectronSelector implements the generic definitions from
+   https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Electrons
 
-    class Electron;
-    class Muon;
+   Analysis-dependent criteria should be implemented in your
+   analysis-specific class inheriting from ElectronSelector.
 
-    /// A class to select electrons
-    class ElectronSelector
-    {
-        public:
-        ElectronSelector();
-        ElectronSelector& setSystematic(const NtSys::SusyNtSys& systematic);
-        ElectronSelector& setAnalysis(const AnalysisType& analysis);
-        /**
-            Method to retrieve the isolation requirement for signal electrons.
-            This is helpful for other tools that need to know how the
-            electrons are defined.
-        */
-        Isolation signalIsolation() { return m_sigIso; }
-        /**
-            Input electron "ele" is required to pass ID quality flags,
-        */
-        bool isBaselineElectron(const Electron* ele);
-        /**
-            Input electron "ele" is required to pass ID quality flags,
-            impact parameter cuts, and isolation cuts.
-        */
-        bool isSignalElectron(const Electron* ele);
-        /**
-            Input electron "ele" is required only to pass ID quality 
-            and impact parameter cuts.
-        */
-        bool isSemiSignalElectron(const Electron* ele); 
-        /**
-            Check whether the input electron "ele" passes a given ID quality 
-            requirement.
-            If "signalQuality" is set true, will check against the analysis'
-            signal electron quality requirement. If set false, this will 
-            check against the analysis' baseline electron quality requirement.
-            Possible IDs: veryLooseLH, looseLH, mediumLH, tightLH,
-                          looseLH_nod0, mediumLH_nod0, tightLH_nod0
-        */
-        bool elecPassID(const Electron* ele, bool signalQuality);
-        /**
-            Check whether the input electron "ele" passes a given isolation quality
-            set by IsolationSelectionTool. 
-        */
-        bool elecPassIsolation(const Electron* ele);
-        /**
-            Get the input electron "ele"'s nominal efficicncy SF
-        */
-        float effSF(const Electron* ele) { return effSF(*ele); }
-        float effSF(const Electron& ele);
-        /**
-            Get the error on the input electron "ele"'s efficiency for
-            the requested systematic
-        */
-        float errEffSF(const Electron* ele, const NtSys::SusyNtSys sys) { return errEffSF(*ele, sys); }
-        float errEffSF(const Electron& ele, const NtSys::SusyNtSys sys);
+   The analysis-specific selector should be instantiated with ElectronsSelector::build().
 
-        void check();
-        
-        /////////////////////////////////////////
-        // Analysis Selections 
-        /////////////////////////////////////////
-        // pT/eta
-        float EL_MIN_PT_BASELINE;       ///< minimum allowed pT for baseline electrons (GeV)
-        float EL_MIN_PT_SIGNAL;         ///< minimum allowed pT for signal electrons (GeV)
-        float EL_MAX_ETA_BASELINE;      ///< maximum allowed eta for baseline electrons
-        float EL_MAX_ETA_SIGNAL;        ///< maximum allowed eta for signal electrons
-        // Isolation
-        float EL_ISO_PT_THRS;
-        float EL_PTCONE30_PT_CUT;       ///< maximum allowed ptcone30/pt 
-        float EL_TOPOCONE30_PT_CUT;     ///< maximum allowed etconetopo30/pt 
-        // IP
-        float EL_MAX_D0SIG;         ///< maximum allowed d0sig
-        float EL_MAX_Z0_SINTHETA;       ///< maximum allowed z0sinTheta
-        // places you don't want to hang around
-        float EL_MIN_CRACK_ETA;         ///< minium crack eta
-        float EL_MAX_CRACK_ETA;         ///< maximum crack eta
+   For details on the design and implementation of this class, see the
+   documentation for JetSelector.
 
- 
-        protected :
-        NtSys::SusyNtSys m_systematic;
-        AnalysisType m_analysis;
-        bool m_vetoCrackRegion; 
-        bool m_doIPCut;
-        
-        ElectronId m_eleBaseId;    ///< electron quality requirement (selected from eleID enum)
-        ElectronId m_eleId;        ///< electron quality requirement (selected from eleID enum)
-        Isolation m_sigIso;        ///< electron isolation qualiy for signal electrons (c.f. SusyNtuple/Isolation.h)
+   davide.gerbaudo@gmail.com, Sep 2015
+*/
+class ElectronSelector
+{
+public:
+    static ElectronSelector* build(const AnalysisType &a, bool verbose);
+    ElectronSelector(); ///< Default ctor
+    virtual ~ElectronSelector() {}; ///< dtor (for now we don't have anything to delete)
 
-        ///////////////////////////////
-        // Available analyses
-        ///////////////////////////////
-        bool m_2lep;    ///< flag for 2L analysis
-        bool m_3lep;    ///< flag for 3L analysis
-        bool m_2lepWH;  ///< flag for 2L WH analysis
-        bool m_SS3L;    ///< flag for the strong SS3L analysis 
-        bool m_stop2l;  ///< flag for the stop to two lepton analysis
+    ElectronSelector& setAnalysis(const AnalysisType& analysis);
 
-        // set verbose
-        bool m_verbose;
-    
-    }; // class
+    /// whether el passes the baseline criteria
+    /**
+       Usually ID + pt + eta + d0sig
+     */
+    virtual bool isBaselineElectron(const Electron* el);
+    /// whether el passes the signal criteria
+    /**
+       Usually baseline + impact parameter + isolation.
+    */
+    virtual bool isSignalElectron(const Electron* el);
 
-} // namepsace Susy
+    virtual bool passIpCut(const Electron &el);
+    virtual bool outsideCrackRegion(const Electron &el);
+
+    /// id of signal electron, used to determine err SF
+    ElectronId signalId() const { return m_signalId; }
+    /// set signal isolation
+    /**
+       Note: the value you set here should match whatever you have in
+       _your_ (overriding) implementation of isSignalElectron()
+     */
+    ElectronSelector& setSignalId(const ElectronId &v) { m_signalId = v; return *this; }
+    /// Retrieve the isolation requirement for signal electrons.
+    /**
+       This is helpful for other tools that need to know how the
+       electrons are defined.
+    */
+    Isolation signalIsolation() const { return m_signalIsolation; }
+    /// set signal isolation
+    /**
+       Note: the value you set here should match whatever you have in
+       _your_ (overriding) implementation of isSignalElectron()
+     */
+    ElectronSelector& setSignalIsolation(const Isolation &v) { m_signalIsolation = v; return *this; }
+
+    /**
+       Get the input electron "ele"'s nominal efficicncy SF
+    */
+    float effSF(const Electron& ele);
+    /// wraps above
+    float effSF(const Electron* ele) { return effSF(*ele); }
+
+    ///  Error on the efficiency for the requested systematic
+    float errEffSF(const Electron& ele, const NtSys::SusyNtSys sys);
+    /// wraps above
+    float errEffSF(const Electron* ele, const NtSys::SusyNtSys sys) { return errEffSF(*ele, sys); }
+
+protected :
+    ElectronId m_signalId;       ///< electron quality requirement (selected from eleID enum)
+    Isolation m_signalIsolation; ///< electron isolation qualiy for signal electrons (c.f. SusyNtuple/Isolation.h)
+    bool m_verbose;
+
+}; // end ElectronSelector
+
+//----------------------------------------------------------
+//
+// End generic selector, begin analysis-specific ones
+//
+//----------------------------------------------------------
+
+/// implements electron selection for ATL-COM-PHYS-2013-911
+class ElectronSelector_2Lep : public ElectronSelector
+{
+};
+
+/// implements electron selection for ATL-COM-PHYS-2013-888
+class ElectronSelector_3Lep : public ElectronSelector
+{
+};
+
+/// implements electron selection for ATL-COM-PHYS-2014-221
+class ElectronSelector_2LepWH : public ElectronSelector
+{
+    virtual bool passIpCut(const Electron &el);
+};
+
+/// implements electron selection from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
+class ElectronSelector_SS3L : public ElectronSelector
+{
+    virtual bool isBaselineElectron(const Electron* el);
+    virtual bool isSignalElectron(const Electron* el);
+};
+
+/// implements electron selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
+class ElectronSelector_Stop2L : public ElectronSelector
+{
+    virtual bool passIpCut(const Electron  &el);
+    virtual bool isSignalElectron(const Electron* el);
+};
+
+} // Susy
 
 #endif
 

--- a/SusyNtuple/ElectronSelector.h
+++ b/SusyNtuple/ElectronSelector.h
@@ -39,12 +39,12 @@ public:
     /**
        Usually ID + pt + eta + d0sig
      */
-    virtual bool isBaselineElectron(const Electron* el);
+    virtual bool isBaseline(const Electron* el);
     /// whether el passes the signal criteria
     /**
        Usually baseline + impact parameter + isolation.
     */
-    virtual bool isSignalElectron(const Electron* el);
+    virtual bool isSignal(const Electron* el);
 
     virtual bool passIpCut(const Electron &el);
     virtual bool outsideCrackRegion(const Electron &el);
@@ -114,15 +114,15 @@ class ElectronSelector_2LepWH : public ElectronSelector
 /// implements electron selection from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
 class ElectronSelector_SS3L : public ElectronSelector
 {
-    virtual bool isBaselineElectron(const Electron* el);
-    virtual bool isSignalElectron(const Electron* el);
+    virtual bool isBaseline(const Electron* el);
+    virtual bool isSignal(const Electron* el);
 };
 
 /// implements electron selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
 class ElectronSelector_Stop2L : public ElectronSelector
 {
     virtual bool passIpCut(const Electron  &el);
-    virtual bool isSignalElectron(const Electron* el);
+    virtual bool isSignal(const Electron* el);
 };
 
 } // Susy

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -69,15 +69,15 @@ public:
     virtual ~JetSelector() {}; ///< dtor (for now we don't have anything to delete)
     JetSelector& setSystematic(const NtSys::SusyNtSys&); ///< set syst (needed for example for jvt)
     /// whether the jet is b-tagged
-    virtual bool isBJet(const Jet* jet);
-    virtual bool isCentralLightJet(const Jet* jet);
-    virtual bool isCentralBJet(const Jet* jet);
-    virtual bool isForwardJet(const Jet* jet);
+    virtual bool isB(const Jet* jet);
+    virtual bool isCentralLight(const Jet* jet);
+    virtual bool isCentralB(const Jet* jet);
+    virtual bool isForward(const Jet* jet);
     /// The jet-vertex-fraction requirement: usually applied to low-pt central jets
     virtual bool passJvt(const Jet* jet);
 
-    virtual bool isBaselineJet(const Jet* jet); ///< often analsysi-dependent
-    virtual bool isSignalJet(const Jet* jet); ///< often analsysi-dependent
+    virtual bool isBaseline(const Jet* jet); ///< often analsysi-dependent
+    virtual bool isSignal(const Jet* jet); ///< often analsysi-dependent
 
     bool verbose() const { return m_verbose; }
     JetSelector& setVerbose(bool v) { m_verbose = v; return *this; }
@@ -134,16 +134,16 @@ class JetSelector_2LepWH : public JetSelector
 /// implements jet selection from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
 class JetSelector_SS3L : public JetSelector
 {
-    virtual bool isBaselineJet(const Jet* jet);
-    virtual bool isSignalJet(const Jet* jet);
-    virtual bool isBJet(const Jet* jet);
+    virtual bool isBaseline(const Jet* jet);
+    virtual bool isSignal(const Jet* jet);
+    virtual bool isB(const Jet* jet);
 };
 
 /// implements jet selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
 class JetSelector_Stop2L : public JetSelector
 {
-    virtual bool isBaselineJet(const Jet* jet);
-    virtual bool isSignalJet(const Jet* jet);
+    virtual bool isBaseline(const Jet* jet);
+    virtual bool isSignal(const Jet* jet);
 };
 
 } // Susy

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -2,9 +2,9 @@
 #ifndef SUSY_JETSELECTOR_H
 #define SUSY_JETSELECTOR_H
 
-#include "SusyNtuple/SusyDefs.h"
 #include "SusyNtuple/SusyNtSys.h"
 #include "SusyNtuple/AnalysisType.h"
+#include "SusyNtuple/SusyDefs.h" // JetVector
 
 namespace Susy {
 
@@ -18,7 +18,7 @@ class Jet;
    Analysis-dependent criteria should be implemented in your
    analysis-specific class inheriting from JetSelector.
 
-   The analysis-specific selector should be generated with JetSelector::build().
+   The analysis-specific selector should be instantiated with JetSelector::build().
 
    Please avoid having thresholds as input parameters of the selection
    functions (including default arguments). Prefer explicit values in
@@ -117,21 +117,21 @@ private:
 //
 //----------------------------------------------------------
 
-/// implements ATL-COM-PHYS-2013-911
+/// implements jet selection from ATL-COM-PHYS-2013-911
 class JetSelector_2Lep : public JetSelector
 {
 };
-/// implements ATL-COM-PHYS-2013-888
+/// implements jet selection from ATL-COM-PHYS-2013-888
 class JetSelector_3Lep : public JetSelector
 {
 };
 
-/// implements ATL-COM-PHYS-2014-221
+/// implements jet selection from ATL-COM-PHYS-2014-221
 class JetSelector_2LepWH : public JetSelector
 {
 };
 
-/// implements https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
+/// implements jet selection from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
 class JetSelector_SS3L : public JetSelector
 {
     virtual bool isBaselineJet(const Jet* jet);
@@ -139,7 +139,7 @@ class JetSelector_SS3L : public JetSelector
     virtual bool isBJet(const Jet* jet);
 };
 
-// TODO Danny add ref wiki
+/// implements jet selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
 class JetSelector_Stop2L : public JetSelector
 {
     virtual bool isBaselineJet(const Jet* jet);

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -7,138 +7,139 @@
 #include "SusyNtuple/AnalysisType.h"
 
 namespace Susy {
+
+class Jet;
+
 ///  A class to select jets
 /**
-   Each analysis has slightly different jet requirements. This class
-   provides a centralized place where such requirements are defined.
+   The generic JetSelector implements the generic definitions from
+   https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Jets
+
+   Analysis-dependent criteria should be implemented in your
+   analysis-specific class inheriting from JetSelector.
+
+   The analysis-specific selector should be generated with JetSelector::build().
+
+   Please avoid having thresholds as input parameters of the selection
+   functions (including default arguments). Prefer explicit values in
+   the function definition, for example:
+   \code{.cpp}
+   JetSelector_myAnalysis::isSignalJet(const Jet* jet)
+   {
+       return (jet->Pt>20.0 && fabs(jet->Eta())<2.4);
+   }
+   \endcode
+   This design has the following advantages:
+
+   1. the default code does not have many 'if else' implementing the
+   analysis-specific selection
+
+   2. the common code can still be shared across groups
+
+   3. the analysis-specific thresholds are explicitly written in the
+   analysis-specific implementation of the overloaded function. This
+   allows to almost copy-and-paste the recommendation from the
+   analysis wiki.
 
    See test_JetSelector.cxx for an example of how this class can be used
 
    Note to self:
    design choices tested in https://gist.github.com/gerbaudo/7854402
 
+   Note to self:
+   since we usually store Jet* in vectors, all the is___() functions
+   take a Jet* as input.
+
+   \todo make the is__() functions const
+   \todo convert the const Jet* argument to const Jet& (and skip all the if(jet) checks)
+
    davide.gerbaudo@gmail.com, Aug 2014
 */
+class JetSelector
+{
+public:
+    /// provide analysis-specific selector (or vanilla one if analysis is unknown)
+    /**
+       The user owns the selector (i.e. should use std::shared_ptr
+       or delete it when done with it).
+    */
+    static JetSelector* build(const AnalysisType &a, bool verbose);
 
-class Jet;
+    JetSelector(); ///< Default ctor
+    virtual ~JetSelector() {}; ///< dtor (for now we don't have anything to delete)
+    JetSelector& setSystematic(const NtSys::SusyNtSys&); ///< set syst (needed for example for jvt)
+    /// whether the jet is b-tagged
+    /**
+       Default values (AntiKt4EMTopoJets) for MV2c20 from
+       https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingBenchmarks#MV2c20_tagger_AntiKt4EMTopoJets
+    */
+    virtual bool isBJet(const Jet* jet);
+    virtual bool isCentralLightJet(const Jet* jet);
+    virtual bool isCentralBJet(const Jet* jet);
+    virtual bool isForwardJet(const Jet* jet);
+    /// The jet-vertex-fraction requirement: usually applied to low-pt central jets
+    virtual bool jetPassesJvtRequirement(const Jet* jet); // TODO rename to passJvt
 
-    class JetSelector
-    {
-        public:
-            /// Vanilla selector
-            JetSelector();
-            /// specify the current syst
-            JetSelector& setSystematic(const NtSys::SusyNtSys&);
-            /// specify the jet requirements for a specific analysis
-            /**
-               This is where all the thresholds are set.
-             */
-            JetSelector& setAnalysis(const AnalysisType&);
-        /*
-          \todo: these will be used internally when refactoring
-        
-            bool isCentral(const Jet &j) { return fabs(j.detEta)<m_max_eta; }
-            bool isCentralLight(const Jet &j) const { return true; }
-            bool isCentralB(const Jet &j) const { return true; }
-            bool isJvfConfirmed(const Jet &j) const { return true; }
-            float minPt() const { return m_min_pt; }
-            float maxEta() const { return m_max_eta; }
-            JetSelector& requireMinPt(float v) { m_min_pt = v; return *this; }
-            JetSelector& requireMaxEta(float v) { m_max_eta = v; return *this; }
-        */
-            // todo:
-            // - make them const
-            bool isBaselineJet(const Jet* jet);
-            bool isSignalJet(const Jet* jet);
-            bool isBJet(const Jet* jet);
-        //    bool isSignalJet2Lep(const Jet* jet);
-            bool isCentralLightJet(const Jet* jet);
-            bool isCentralBJet(const Jet* jet);
-            bool isForwardJet(const Jet* jet);
-        //    bool isBadFCALJet(const Jet* jet);
-        //    bool hasJetInBadFCAL(const JetVector& baseJets, uint run, bool isMC);
-        
-            bool selects(const Jet* j) const { return false; } ///< placeholder
-            bool verbose() const { return m_verbose; }
-            JetSelector& setVerbose(bool v) { m_verbose = v; return *this; }
-        
-            // The jet-vertex-fraction requirement: usually applied to low-pt central jets
-        //    bool jetPassesJvfRequirement(const Jet* jet);
-            bool jetPassesJvtRequirement(const Jet* jet);
-        
-            /// count central light jets \todo const (depends on jvf tool interface)
-            size_t count_CL_jets(const JetVector &jets) /*const*/;
-            /// count central b-tagged jets \todo const
-            size_t count_CB_jets(const JetVector &jets) /*const*/;
-            /// count forward jets \todo const
-            size_t count_F_jets(const JetVector &jets) /*const*/;
-        
-        //    float m_min_pt; ///< do not consider jets with pt below this value
-        //    float m_max_eta; ///< do not consider jets with eta above this value
+    virtual bool isBaselineJet(const Jet* jet); ///< often analsysi-dependent
+    virtual bool isSignalJet(const Jet* jet); ///< often analsysi-dependent
 
-            float overlapRemovalBtagEffWP() { return JET_MV2C20_OR; }
+    bool verbose() const { return m_verbose; }
+    JetSelector& setVerbose(bool v) { m_verbose = v; return *this; }
 
-            void check();
+    /// count central light jets \todo const (depends on jvf tool interface)
+    virtual size_t count_CL_jets(const JetVector &jets) /*const*/;
+    /// count central b-tagged jets \todo const
+    virtual size_t count_CB_jets(const JetVector &jets) /*const*/;
+    /// count forward jets \todo const
+    virtual size_t count_F_jets(const JetVector &jets) /*const*/;
 
-            ////////////////////////////////////
-            // Analysis Selections 
-            ////////////////////////////////////
-            // pt/eta
-            float JET_MIN_PT_BASELINE;  ///< minimum allowed jet pT (GeV)
-            float JET_MIN_PT_SIGNAL;    ///< signal jet pT cut
-            float JET_MIN_PT_L25;       ///< signal CL25 jet pT cut (name is redundant?)
-            float JET_MIN_PT_L20;       ///< signal CL20 jet pT cut (name is redundant?)
-            float JET_MIN_PT_B20;       ///< signal CL b-jet pT cut
-            float JET_MIN_PT_F30;       ///< signal forward-jet pT cut
-            float JET_MAX_ETA;          ///< maximum allowed eta for signal jets
-            float JET_MAX_ETA_FORWARD;  ///< maximum allowed eta for forward signal jets
-            // jvt
-            float JET_JVT_CUT;          ///< JVT threshold value
-            float JET_JVT_ETA_CUT;      ///< eta threshold for applying JVT cut (eta must be below this to apply JVT)
-            float JET_JVT_PT_CUT;       ///< pT threshold for applying JVT cut (pT must be below this to apply JVT)
-            // b-tagging
-            float JET_MV2C20_85;        ///< fixed cut 85% b-tag efficiency WP
-            float JET_MV2C20_80;        ///< fixed cut 80% b-tag efficiency WP
-            float JET_MV2C20_77;        ///< fixed cut 77% b-tag efficiency WP
-            float JET_MV2C20_70;        ///< fixed cut 70% b-tag efficiency WP
-            float JET_MV2C20_60;        ///< fixed cut 60% b-tag efficiency WP
-            float JET_MV2C20_OR;        ///< fixed cut b-tag efficiency WP used in b-jet OR procedure
-    
-        private:
-            NtSys::SusyNtSys m_systematic; ///< current syst variation
-            AnalysisType m_analysis; ///< analysis
-    
-            //////////////////////////////
-            // Available analyses
-            //////////////////////////////
-            bool m_2lep;    ///< flag for 2L analysis
-            bool m_3lep;    ///< flag for 3L analysis
-            bool m_2lepWH;  ///< flag for 2L WH analysis
-            bool m_SS3L;    ///< flag for the strong SS3L analysis
-            bool m_stop2l;  ///< flag for the stop to two lepton analysis
-    
-            bool m_verbose; ///< toggle verbose messages
-
+    /// For the overlap removal: a different b-tag threshold is used
+    /**
+       80% eff see
+       https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#b_tagging
+     */
+    static float overlapRemovalBtagEffWP() { return -0.5911; }
+private:
+    NtSys::SusyNtSys m_systematic; ///< current syst variation
+    bool m_verbose; ///< toggle verbose messages
     }; // class JetSelector
 
-    //----------------------------------------------------------
-    /// wrapper functor to be used with std algorithms
-    /**
-       Note to self: in order for this to be a well-behaved functor,
-       I can only provide one operator()(const Lepton *l), and not
-               (const Lepton *l) + (const Lepton &l).
-       Otherwise I won't be able to use the std function adapters (namely
-       not1). See Item 40 of S.Meyer's "Effective STL".
-    */
-    class JetSelectorFunctor : public std::unary_function<const Jet*, bool>
-    {
-        public:
-            JetSelectorFunctor(const JetSelector &js): m_selector(js) {};
-            bool operator() (const Jet *j) const { return m_selector.selects(j); }
-        private:
-            const JetSelector &m_selector;
-    };
-    //----------------------------------------------------------
+
+//----------------------------------------------------------
+//
+// End generic selector, begin analysis-specific ones
+//
+//----------------------------------------------------------
+
+/// implements ATL-COM-PHYS-2013-911
+class JetSelector_2Lep : public JetSelector
+{
+};
+/// implements ATL-COM-PHYS-2013-888
+class JetSelector_3Lep : public JetSelector
+{
+};
+
+/// implements ATL-COM-PHYS-2014-221
+class JetSelector_2LepWH : public JetSelector
+{
+};
+
+/// implements https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
+class JetSelector_ss3l : public JetSelector
+{
+    virtual bool isBaselineJet(const Jet* jet);
+    virtual bool isSignalJet(const Jet* jet);
+    virtual bool isBJet(const Jet* jet);
+    virtual bool passJvt(const Jet* jet);
+};
+
+// TODO Danny add ref wiki
+class JetSelector_Stop2L : public JetSelector
+{
+    virtual bool isBaselineJet(const Jet* jet);
+    virtual bool isSignalJet(const Jet* jet);
+};
 
 } // Susy
 

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -78,7 +78,7 @@ public:
     virtual bool isCentralBJet(const Jet* jet);
     virtual bool isForwardJet(const Jet* jet);
     /// The jet-vertex-fraction requirement: usually applied to low-pt central jets
-    virtual bool jetPassesJvtRequirement(const Jet* jet); // TODO rename to passJvt
+    virtual bool passJvt(const Jet* jet);
 
     virtual bool isBaselineJet(const Jet* jet); ///< often analsysi-dependent
     virtual bool isSignalJet(const Jet* jet); ///< often analsysi-dependent
@@ -131,7 +131,6 @@ class JetSelector_ss3l : public JetSelector
     virtual bool isBaselineJet(const Jet* jet);
     virtual bool isSignalJet(const Jet* jet);
     virtual bool isBJet(const Jet* jet);
-    virtual bool passJvt(const Jet* jet);
 };
 
 // TODO Danny add ref wiki

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -69,10 +69,6 @@ public:
     virtual ~JetSelector() {}; ///< dtor (for now we don't have anything to delete)
     JetSelector& setSystematic(const NtSys::SusyNtSys&); ///< set syst (needed for example for jvt)
     /// whether the jet is b-tagged
-    /**
-       Default values (AntiKt4EMTopoJets) for MV2c20 from
-       https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingBenchmarks#MV2c20_tagger_AntiKt4EMTopoJets
-    */
     virtual bool isBJet(const Jet* jet);
     virtual bool isCentralLightJet(const Jet* jet);
     virtual bool isCentralBJet(const Jet* jet);
@@ -85,7 +81,6 @@ public:
 
     bool verbose() const { return m_verbose; }
     JetSelector& setVerbose(bool v) { m_verbose = v; return *this; }
-
     /// count central light jets \todo const (depends on jvf tool interface)
     virtual size_t count_CL_jets(const JetVector &jets) /*const*/;
     /// count central b-tagged jets \todo const
@@ -93,12 +88,23 @@ public:
     /// count forward jets \todo const
     virtual size_t count_F_jets(const JetVector &jets) /*const*/;
 
-    /// For the overlap removal: a different b-tag threshold is used
+    //@{
     /**
-       80% eff see
+       b-tag operating points for AntiKt4EMTopoJets with MV2c20.
+       See
+       https://twiki.cern.ch/twiki/bin/view/AtlasProtected/BTaggingBenchmarks#MV2c20_tagger_AntiKt4EMTopoJets
+    */
+    static float mv2c20_70efficiency() { return -0.0436; } ///< threshold for 70% efficiency
+    static float mv2c20_77efficiency() { return -0.4434; } ///< threshold for 77% efficiency
+    static float mv2c20_80efficiency() { return -0.5911; } ///< threshold for 80% efficiency
+
+    /// b-tag operating point used for the overlap removal.
+    /**
+       See
        https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#b_tagging
      */
-    static float overlapRemovalBtagEffWP() { return -0.5911; }
+    static float overlapRemovalBtagEffWP() { return mv2c20_80efficiency(); }
+    //@}
 private:
     NtSys::SusyNtSys m_systematic; ///< current syst variation
     bool m_verbose; ///< toggle verbose messages

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -132,7 +132,7 @@ class JetSelector_2LepWH : public JetSelector
 };
 
 /// implements https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
-class JetSelector_ss3l : public JetSelector
+class JetSelector_SS3L : public JetSelector
 {
     virtual bool isBaselineJet(const Jet* jet);
     virtual bool isSignalJet(const Jet* jet);

--- a/SusyNtuple/MuonSelector.h
+++ b/SusyNtuple/MuonSelector.h
@@ -2,7 +2,6 @@
 #ifndef SUSYNTUPLE_MUONSELECTOR_H
 #define SUSYNTUPLE_MUONSELECTOR_H
 
-#include "SusyNtuple/SusyDefs.h"
 #include "SusyNtuple/SusyNtSys.h"
 #include "SusyNtuple/AnalysisType.h"
 #include "SusyNtuple/Isolation.h"
@@ -11,18 +10,17 @@
 
 namespace Susy {
 
-class Electron;
 class Muon;
 
 /// A class to select muons
 /**
-   The generic JetSelector implements the generic definitions from
+   The generic MuonSelector implements the generic definitions from
    https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SusyObjectDefinitionsr2013TeV#Muons
 
    Analysis-dependent criteria should be implemented in your
    analysis-specific class inheriting from MuonSelector.
 
-   The analysis-specific selector should be generated with MuonsSelector::build().
+   The analysis-specific selector should be instantiated with MuonsSelector::build().
 
    For details on the design and implementation of this class, see the
    documentation for JetSelector.
@@ -50,9 +48,6 @@ public :
     /// whether mu is close enough to the primary vertex
     virtual bool passIpCut(const Muon* mu);
     /// nominal efficiency scale factor of mu
-    /**
-       \param id required quality of the (signal) muon
-     */
     virtual float effSF(const Muon& mu);
     /// wraps effSF() above
     virtual float effSF(const Muon* mu) { return effSF(*mu); }
@@ -63,7 +58,7 @@ public :
                            const NtSys::SusyNtSys sys)
         { return errEffSF(*mu, sys); }
     /// isolation required for signal muon
-    Isolation signalMuonIsolation() { return m_signalIsolation; }
+    Isolation signalMuonIsolation() const { return m_signalIsolation; }
     /// set signal isolation
     /**
        Note: the value you set here should match whatever you have in
@@ -71,7 +66,7 @@ public :
      */
     MuonSelector& setSignalMuonIsolation(const Isolation &v) { m_signalIsolation = v; return *this; }
     /// id of signal muon, used to determine err SF
-    MuonId signalMuonId() { return m_signalId; }
+    MuonId signalMuonId() const { return m_signalId; }
     /**
        Note: the value you set here should match whatever you have in
        _your_ (overriding) implementation of isSignalMuon()
@@ -86,6 +81,11 @@ protected :
 
 }; // end MuonSelector
 
+//----------------------------------------------------------
+//
+// End generic selector, begin analysis-specific ones
+//
+//----------------------------------------------------------
 
 /// implements muon selection for ATL-COM-PHYS-2013-911
 class MuonSelector_2Lep : public MuonSelector
@@ -112,7 +112,7 @@ class MuonSelector_SS3L : public MuonSelector
     virtual bool isSignalMuon(const Muon* mu);
 };
 
-// TODO Danny add ref wiki
+/// implements Muon selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
 class MuonSelector_Stop2L : public MuonSelector
 {
     virtual bool passIpCut(const Muon* mu);

--- a/SusyNtuple/MuonSelector.h
+++ b/SusyNtuple/MuonSelector.h
@@ -72,8 +72,8 @@ public :
        _your_ (overriding) implementation of isSignal()
      */
     MuonSelector& setSignalId(const MuonId &v) { m_signalId = v; return *this; }
-    bool verbose() { return m_verbose; }
     MuonSelector& setVerbose(const bool &v) { m_verbose = v; return *this; }
+    bool verbose() const { return m_verbose; }
 protected :
     MuonId m_signalId; ///< required quality of the signal muon
     Isolation m_signalIsolation; ///< required to propagate to OverlapTools

--- a/SusyNtuple/MuonSelector.h
+++ b/SusyNtuple/MuonSelector.h
@@ -39,12 +39,12 @@ public :
     static MuonSelector* build(const AnalysisType &a, bool verbose);
     MuonSelector();  ///< Default ctor
     virtual ~MuonSelector() {}; ///< dtor (for now we don't have anything to delete)
-    virtual bool isBaselineMuon(const Muon* mu); ///< whether mu passes the baseline criteria
+    virtual bool isBaseline(const Muon* mu); ///< whether mu passes the baseline criteria
     /// whether mu passes the signal criteria
     /**
        Usually baseline + impact parameter + isolation.
     */
-    virtual bool isSignalMuon(const Muon* mu);
+    virtual bool isSignal(const Muon* mu);
     /// whether mu is close enough to the primary vertex
     virtual bool passIpCut(const Muon* mu);
     /// nominal efficiency scale factor of mu
@@ -62,14 +62,14 @@ public :
     /// set signal isolation
     /**
        Note: the value you set here should match whatever you have in
-       _your_ (overriding) implementation of isSignalMuon()
+       _your_ (overriding) implementation of isSignal()
      */
     MuonSelector& setSignalIsolation(const Isolation &v) { m_signalIsolation = v; return *this; }
     /// id of signal muon, used to determine err SF
     MuonId signalId() const { return m_signalId; }
     /**
        Note: the value you set here should match whatever you have in
-       _your_ (overriding) implementation of isSignalMuon()
+       _your_ (overriding) implementation of isSignal()
      */
     MuonSelector& setSignalId(const MuonId &v) { m_signalId = v; return *this; }
     bool verbose() { return m_verbose; }
@@ -95,29 +95,29 @@ class MuonSelector_2Lep : public MuonSelector
 /// implements muon selection for ATL-COM-PHYS-2013-888
 class MuonSelector_3Lep : public MuonSelector
 {
-    virtual bool isSignalMuon(const Muon* mu);
+    virtual bool isSignal(const Muon* mu);
 };
 
 /// implements muon selection for ATL-COM-PHYS-2014-221
 class MuonSelector_2LepWH : public MuonSelector
 {
-    virtual bool isSignalMuon(const Muon* mu);
+    virtual bool isSignal(const Muon* mu);
 };
 
 /// implements https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
 class MuonSelector_SS3L : public MuonSelector
 {
     virtual bool passIpCut(const Muon* mu);
-    virtual bool isBaselineMuon(const Muon* mu);
-    virtual bool isSignalMuon(const Muon* mu);
+    virtual bool isBaseline(const Muon* mu);
+    virtual bool isSignal(const Muon* mu);
 };
 
 /// implements Muon selection from https://twiki.cern.ch/twiki/bin/view/AtlasProtected/DirectStop2Lepton
 class MuonSelector_Stop2L : public MuonSelector
 {
     virtual bool passIpCut(const Muon* mu);
-    virtual bool isBaselineMuon(const Muon* mu);
-    virtual bool isSignalMuon(const Muon* mu);
+    virtual bool isBaseline(const Muon* mu);
+    virtual bool isSignal(const Muon* mu);
 };
 
 } // end namespace

--- a/SusyNtuple/MuonSelector.h
+++ b/SusyNtuple/MuonSelector.h
@@ -58,20 +58,20 @@ public :
                            const NtSys::SusyNtSys sys)
         { return errEffSF(*mu, sys); }
     /// isolation required for signal muon
-    Isolation signalMuonIsolation() const { return m_signalIsolation; }
+    Isolation signalIsolation() const { return m_signalIsolation; }
     /// set signal isolation
     /**
        Note: the value you set here should match whatever you have in
        _your_ (overriding) implementation of isSignalMuon()
      */
-    MuonSelector& setSignalMuonIsolation(const Isolation &v) { m_signalIsolation = v; return *this; }
+    MuonSelector& setSignalIsolation(const Isolation &v) { m_signalIsolation = v; return *this; }
     /// id of signal muon, used to determine err SF
-    MuonId signalMuonId() const { return m_signalId; }
+    MuonId signalId() const { return m_signalId; }
     /**
        Note: the value you set here should match whatever you have in
        _your_ (overriding) implementation of isSignalMuon()
      */
-    MuonSelector& setSignalMuonId(const MuonId &v) { m_signalId = v; return *this; }
+    MuonSelector& setSignalId(const MuonId &v) { m_signalId = v; return *this; }
     bool verbose() { return m_verbose; }
     MuonSelector& setVerbose(const bool &v) { m_verbose = v; return *this; }
 protected :

--- a/SusyNtuple/OverlapTools.h
+++ b/SusyNtuple/OverlapTools.h
@@ -97,8 +97,6 @@ class OverlapTools_2LepWH : public OverlapTools
 
 /// implements OR procedure from https://twiki.cern.ch/twiki/bin/viewauth/AtlasProtected/SUSYSameSignLeptonsJetsRun2
 class OverlapTools_SS3L: public OverlapTools {
-    virtual void performOverlap(ElectronVector& electrons, MuonVector& muons,
-                                TauVector& taus, JetVector& jets);
     /// different from OverlapTools::j_e_overlap() : performs BjetOR
     virtual void j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR);
 };

--- a/SusyNtuple/SusyNtAna.h
+++ b/SusyNtuple/SusyNtAna.h
@@ -97,7 +97,7 @@ class SusyNtAna : public TSelector
     
     void setEvtDebug() { m_dbgEvt = true; }
     bool dbgEvt() const { return m_dbgEvt; }
-    void loadEventList();
+    void loadEventList(const std::string filename="debugEvents.txt");
     bool processThisEvent(unsigned int run, unsigned int event);
     bool checkRunEvent(const RunEventMap &runEventMap, unsigned int run, unsigned int event);
     bool checkAndAddRunEvent(RunEventMap &runEventMap, unsigned int run, unsigned int event);

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -55,7 +55,7 @@ public:
     //
     // Methods to return the tools
     //
-    ElectronSelector&   electronSelector()   { return m_electronSelector; }
+    ElectronSelector&   electronSelector()   { return *m_electronSelector; }
     MuonSelector&       muonSelector()       { return *m_muonSelector; }
     TauSelector&        tauSelector()        { return m_tauSelector; }
     JetSelector&        jetSelector()        { return *m_jetSelector; }
@@ -125,7 +125,6 @@ public:
     bool isSignalMuon(const Susy::Muon* m);
     bool isSignalTau(const Susy::Tau* tau, TauId tauJetID = TauId::Medium,
                      TauId tauEleID = TauId::Loose, TauId tauMuoID = TauId::Medium);
-    bool isSemiSignalElectron(const Susy::Electron* ele);
 
     /// Build lepton vector, sort by pT
     void buildLeptons(LeptonVector &lep, const ElectronVector& ele, const MuonVector& muo);
@@ -186,14 +185,13 @@ public:
         }
     }
 
-    // protected:
-    # warning make protected
+    // \todo make these datamembers protected
     // Object Selectors and Tools
-    ElectronSelector m_electronSelector;
-    MuonSelector* m_muonSelector;              ///< select muons according to the current analysis settings
+    ElectronSelector* m_electronSelector; ///< select electrons according to the current analysis settings
+    MuonSelector* m_muonSelector;         ///< select muons according to the current analysis settings
     TauSelector  m_tauSelector;
-    JetSelector* m_jetSelector;              ///< select jets according to the current analysis settings
-    OverlapTools m_overlapTool;             ///< tool to perform the analysis' OR procedure
+    JetSelector* m_jetSelector;           ///< select jets according to the current analysis settings
+    OverlapTools m_overlapTool;           ///< tool to perform the analysis' OR procedure
     TriggerTools m_triggerTool;  ///< tool to access the trigger information
 
 protected:

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -57,7 +57,7 @@ public:
     //
     ElectronSelector&   electronSelector()   { return *m_electronSelector; }
     MuonSelector&       muonSelector()       { return *m_muonSelector; }
-    TauSelector&        tauSelector()        { return m_tauSelector; }
+    TauSelector&        tauSelector()        { return *m_tauSelector; }
     JetSelector&        jetSelector()        { return *m_jetSelector; }
     OverlapTools&       overlapTool()        { return m_overlapTool; }
     TriggerTools&       triggerTool()        { return m_triggerTool; }
@@ -115,16 +115,14 @@ public:
     ElectronVector getSignalElectrons(const ElectronVector& baseElecs);
     MuonVector     getSignalMuons(const MuonVector& baseMuons);
     PhotonVector   getSignalPhotons(Susy::SusyNtObject* susyNt);
-    TauVector      getSignalTaus(const TauVector& baseTaus, TauId tauJetID = TauId::Medium,
-                                 TauId tauEleID = TauId::Loose, TauId tauMuoID = TauId::Medium);
+    TauVector      getSignalTaus(const TauVector& baseTaus);
     JetVector      getSignalJets(const JetVector& baseJets);
 
     /// Check if signal object
     bool isSignalLepton(const Susy::Lepton* l);
     bool isSignalElectron(const Susy::Electron* e);
     bool isSignalMuon(const Susy::Muon* m);
-    bool isSignalTau(const Susy::Tau* tau, TauId tauJetID = TauId::Medium,
-                     TauId tauEleID = TauId::Loose, TauId tauMuoID = TauId::Medium);
+    bool isSignalTau(const Susy::Tau* tau);
 
     /// Build lepton vector, sort by pT
     void buildLeptons(LeptonVector &lep, const ElectronVector& ele, const MuonVector& muo);
@@ -189,7 +187,7 @@ public:
     // Object Selectors and Tools
     ElectronSelector* m_electronSelector; ///< select electrons according to the current analysis settings
     MuonSelector* m_muonSelector;         ///< select muons according to the current analysis settings
-    TauSelector  m_tauSelector;
+    TauSelector*  m_tauSelector;          ///< select taus according to the current analysis settings
     JetSelector* m_jetSelector;           ///< select jets according to the current analysis settings
     OverlapTools m_overlapTool;           ///< tool to perform the analysis' OR procedure
     TriggerTools m_triggerTool;  ///< tool to access the trigger information

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -56,7 +56,7 @@ public:
     // Methods to return the tools
     //
     ElectronSelector&   electronSelector()   { return m_electronSelector; }
-    MuonSelector&       muonSelector()       { return m_muonSelector; }
+    MuonSelector&       muonSelector()       { return *m_muonSelector; }
     TauSelector&        tauSelector()        { return m_tauSelector; }
     JetSelector&        jetSelector()        { return *m_jetSelector; }
     OverlapTools&       overlapTool()        { return m_overlapTool; }
@@ -126,7 +126,6 @@ public:
     bool isSignalTau(const Susy::Tau* tau, TauId tauJetID = TauId::Medium,
                      TauId tauEleID = TauId::Loose, TauId tauMuoID = TauId::Medium);
     bool isSemiSignalElectron(const Susy::Electron* ele);
-    bool isSemiSignalMuon(const Susy::Muon* mu);
 
     /// Build lepton vector, sort by pT
     void buildLeptons(LeptonVector &lep, const ElectronVector& ele, const MuonVector& muo);
@@ -191,7 +190,7 @@ public:
     # warning make protected
     // Object Selectors and Tools
     ElectronSelector m_electronSelector;
-    MuonSelector m_muonSelector;
+    MuonSelector* m_muonSelector;              ///< select muons according to the current analysis settings
     TauSelector  m_tauSelector;
     JetSelector* m_jetSelector;              ///< select jets according to the current analysis settings
     OverlapTools m_overlapTool;             ///< tool to perform the analysis' OR procedure

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -59,7 +59,7 @@ public:
     MuonSelector&       muonSelector()       { return *m_muonSelector; }
     TauSelector&        tauSelector()        { return *m_tauSelector; }
     JetSelector&        jetSelector()        { return *m_jetSelector; }
-    OverlapTools&       overlapTool()        { return m_overlapTool; }
+    OverlapTools&       overlapTool()        { return *m_overlapTool; }
     TriggerTools&       triggerTool()        { return m_triggerTool; }
 
     //
@@ -189,7 +189,7 @@ public:
     MuonSelector* m_muonSelector;         ///< select muons according to the current analysis settings
     TauSelector*  m_tauSelector;          ///< select taus according to the current analysis settings
     JetSelector* m_jetSelector;           ///< select jets according to the current analysis settings
-    OverlapTools m_overlapTool;           ///< tool to perform the analysis' OR procedure
+    OverlapTools* m_overlapTool;          ///< tool to perform the analysis' OR procedure
     TriggerTools m_triggerTool;  ///< tool to access the trigger information
 
 protected:

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -119,10 +119,10 @@ public:
     JetVector      getSignalJets(const JetVector& baseJets);
 
     /// Check if signal object
-    bool isSignalLepton(const Susy::Lepton* l);
-    bool isSignalElectron(const Susy::Electron* e);
-    bool isSignalMuon(const Susy::Muon* m);
-    bool isSignalTau(const Susy::Tau* tau);
+    bool isSignal(const Susy::Lepton* l);
+    bool isSignal(const Susy::Electron* e);
+    bool isSignal(const Susy::Muon* m);
+    bool isSignal(const Susy::Tau* tau);
 
     /// Build lepton vector, sort by pT
     void buildLeptons(LeptonVector &lep, const ElectronVector& ele, const MuonVector& muo);

--- a/SusyNtuple/SusyNtTools.h
+++ b/SusyNtuple/SusyNtTools.h
@@ -30,9 +30,7 @@ public:
 
     /// Constructor and destructor
     SusyNtTools();
-    virtual ~SusyNtTools()
-    {
-    };
+    virtual ~SusyNtTools();
 
     void setSFOSRemoval(AnalysisType A);
     bool doSFOSRemoval() { return m_doSFOS; }
@@ -42,44 +40,7 @@ public:
         Set AnalysisType to determine object selections
         and overlap procedure
     */
-    void setAnaType(AnalysisType A, bool verbose = false)
-    {
-        ////////////////////////////
-        // ElectronSelector
-        ////////////////////////////
-        m_electronSelector.setAnalysis(A);
-        ////////////////////////////
-        // MuonSelector
-        ////////////////////////////
-        m_muonSelector.setAnalysis(A);
-        ////////////////////////////
-        // TauSelector
-        ////////////////////////////
-        m_tauSelector.setAnalysis(A);
-        ////////////////////////////
-        // JetSelector
-        ////////////////////////////
-        m_jetSelector.setAnalysis(A);
-        ////////////////////////////
-        // OverlapTool
-        ////////////////////////////
-        // propagate isolation requirements
-        m_overlapTool.setElectronIsolation(m_electronSelector.signalIsolation());
-        m_overlapTool.setMuonIsolation(m_muonSelector.signalIsolation());
-        // propagate OR loose b-tag WP
-        m_overlapTool.setORBtagEff(m_jetSelector.overlapRemovalBtagEffWP());
-        // now setAnalysis
-        m_overlapTool.setAnalysis(A);
-
-        // set whether to perform SFOS removal on baseline objects
-        setSFOSRemoval(A);
-
-        // this should be in the logs no matter what
-        std::cout << ">>> Setting analysis type to " << AnalysisType2str(A) << std::endl;
-
-        // now that the tools are configured set this variable
-        m_anaType = A;
-    };
+    void setAnaType(AnalysisType A, bool verbose = false);
     AnalysisType getAnaType() { return m_anaType; }
 
     /// initialize the trigger tool; return success
@@ -94,12 +55,12 @@ public:
     //
     // Methods to return the tools
     //
-    ElectronSelector&   getElectronSelector()   { return m_electronSelector; }
-    MuonSelector&       getMuonSelector()       { return m_muonSelector; }
-    TauSelector&        getTauSelector()        { return m_tauSelector; }
-    JetSelector&        getJetSelector()        { return m_jetSelector; }
-    OverlapTools&       getOverlapTools()       { return m_overlapTool; }
-    TriggerTools&       triggerTool()           { return m_triggerTool; }
+    ElectronSelector&   electronSelector()   { return m_electronSelector; }
+    MuonSelector&       muonSelector()       { return m_muonSelector; }
+    TauSelector&        tauSelector()        { return m_tauSelector; }
+    JetSelector&        jetSelector()        { return *m_jetSelector; }
+    OverlapTools&       overlapTool()        { return m_overlapTool; }
+    TriggerTools&       triggerTool()        { return m_triggerTool; }
 
     //
     // Methods to perform event selection
@@ -226,13 +187,13 @@ public:
         }
     }
 
-    /////////////////////////////////////////////
+    // protected:
+    # warning make protected
     // Object Selectors and Tools
-    /////////////////////////////////////////////
     ElectronSelector m_electronSelector;
     MuonSelector m_muonSelector;
     TauSelector  m_tauSelector;
-    JetSelector m_jetSelector;              ///< select jets according to the current analysis settings
+    JetSelector* m_jetSelector;              ///< select jets according to the current analysis settings
     OverlapTools m_overlapTool;             ///< tool to perform the analysis' OR procedure
     TriggerTools m_triggerTool;  ///< tool to access the trigger information
 

--- a/SusyNtuple/TauSelector.h
+++ b/SusyNtuple/TauSelector.h
@@ -39,16 +39,16 @@ public:
     /**
        Usually pt+bdt
     */
-    virtual bool isBaselineTau(const Tau& tau);
+    virtual bool isBaseline(const Tau& tau);
     /// wraps above
-    bool isBaselineTau(const Tau* tau) { return isBaselineTau(*tau); }
+    bool isBaseline(const Tau* tau) { return isBaseline(*tau); }
     /// whether tau passes the signal criteria
     /**
        Usually baseline + bdt
     */
-    virtual bool isSignalTau(const Tau& tau);
+    virtual bool isSignal(const Tau& tau);
     /// wraps above
-    virtual bool isSignalTau(const Tau* tau) { return isSignalTau(*tau); }
+    virtual bool isSignal(const Tau* tau) { return isSignal(*tau); }
     /// \todo document
     virtual bool passBdtBaseline(const Tau&);
     /// \todo document

--- a/util/test_JetSelector.cxx
+++ b/util/test_JetSelector.cxx
@@ -38,11 +38,11 @@ int main(int argc, char **argv)
     JetSelector &s = *selector;
 
     bool passAll = true;
-    passAll &= (s.isCentralLightJet(&centralLightJet)==true);
-    passAll &= (s.isBJet           (&centralLightJet)==false);
-    passAll &= (s.isCentralLightJet(&centralBJet    )==false);
-    passAll &= (s.isBJet           (&centralBJet    )==true);
-    passAll &= (s.isForwardJet     (&forwardJet     )==false);
+    passAll &= (s.isCentralLight(&centralLightJet)==true);
+    passAll &= (s.isB           (&centralLightJet)==false);
+    passAll &= (s.isCentralLight(&centralBJet    )==false);
+    passAll &= (s.isB           (&centralBJet    )==true);
+    passAll &= (s.isForward     (&forwardJet     )==false);
     // \todo test jfv, test analysis-specific cuts
     cout<<"JetSelector: "<<(passAll ? "passed all tests" : "failed some test")<<endl;
 

--- a/util/test_JetSelector.cxx
+++ b/util/test_JetSelector.cxx
@@ -46,5 +46,7 @@ int main(int argc, char **argv)
     // \todo test jfv, test analysis-specific cuts
     cout<<"JetSelector: "<<(passAll ? "passed all tests" : "failed some test")<<endl;
 
+    delete selector;
+
     return passAll;
 }

--- a/util/test_JetSelector.cxx
+++ b/util/test_JetSelector.cxx
@@ -17,27 +17,34 @@ int main(int argc, char **argv)
     bool verbose(true);
     if(verbose)
         cout<<"Being called as: "<<Susy::utils::commandLineArguments(argc, argv)<<endl;
-//    float epsilon = 0.01;
+    // two eta values to test central/fw jets:
+    // high-eta is usually from 2.4-2.8 to 4.5
+    float lowEtaCalo(0.5), highEtaCalo(3.5);
+
     Jet centralLightJet;
-//    centralLightJet.SetPtEtaPhiE(100.0, JetSelector::defaultCentralEtaMax()-epsilon, 0.1, 100.0);
+    centralLightJet.SetPtEtaPhiE(100.0, lowEtaCalo, 0.1, 100.0);
     centralLightJet.detEta = centralLightJet.Eta();
+    centralLightJet.mv2c20 = -1.0; // low (~-1) mva output is not btagged
+
+
     Jet centralBJet(centralLightJet);
-//    centralBJet.mv1 = JetSelector::defaultBtagMinValue()+epsilon;
+    centralBJet.mv2c20 = +1.0; // high (~1) mva output is btagged
+
     Jet forwardJet(centralLightJet);
-//    forwardJet.SetPtEtaPhiE(100.0, JetSelector::defaultCentralEtaMax()+epsilon, 0.1, 100.0);
+    forwardJet.SetPtEtaPhiE(100.0, highEtaCalo, 0.1, 100.0);
 
 
-    JetSelector selector = JetSelector().setAnalysis(AnalysisType::Ana_2Lep).setVerbose(verbose);
+    JetSelector *selector = JetSelector::build(AnalysisType::Ana_2Lep, verbose);
+    JetSelector &s = *selector;
 
     bool passAll = true;
-    // passAll &= (selector.isCentral     (centralLightJet)==true);
-    // passAll &= (selector.isCentralLight(centralLightJet)==true);
-    // passAll &= (selector.isCentralB    (centralLightJet)==false);
-    // passAll &= (selector.isCentralLight(centralBJet    )==false);
-    // passAll &= (selector.isCentralBJet (centralBJet    )==true);
-    // passAll &= (selector.isForwardJet  (forwardJet     )==false);
+    passAll &= (s.isCentralLightJet(&centralLightJet)==true);
+    passAll &= (s.isBJet           (&centralLightJet)==false);
+    passAll &= (s.isCentralLightJet(&centralBJet    )==false);
+    passAll &= (s.isBJet           (&centralBJet    )==true);
+    passAll &= (s.isForwardJet     (&forwardJet     )==false);
     // \todo test jfv, test analysis-specific cuts
     cout<<"JetSelector: "<<(passAll ? "passed all tests" : "failed some test")<<endl;
-    
+
     return passAll;
 }


### PR DESCRIPTION
This is the initial version of what I suggested yesterday
for the Selector implementation.
For now I started with the `JetSelector`. If you think this looks
reasonable, I'll modify in the same way `ElectronSelector`
and `MuonSelector`.

The base class `JetSelector` holds the "vanilla" jet selection criteria.
The derived classes `JetSelector_ss3l`, `JetSelector_Stop2L` , etc.,
hold the analysis-specific selection criteria.

The idea is to have the explicit definition of each selection criteria
in the code, so that one can almost copy-and-paste from the analysis'
wiki to the code. See for example `JetSelector_ss3l::isSignalJet()`.
I believe that this is much easier to follow than having the thresholds
set in one place and the `if(value<thresh)` elsewhere.

Note to self: requires #76 