### PR TITLE
Autoguess samplename

### DIFF
--- a/Root/ChainHelper.cxx
+++ b/Root/ChainHelper.cxx
@@ -2,6 +2,7 @@
 #include "SusyNtuple/string_utils.h"
 #include "TObjArray.h"
 #include "TChainElement.h"
+#include "TKey.h"
 
 #include <iostream>
 
@@ -111,5 +112,28 @@ bool ChainHelper::inputIsList(const std::string &input)
 bool ChainHelper::inputIsDir(const std::string &input)
 {
     return Susy::utils::endswith(Susy::utils::rmLeadingTrailingWhitespaces(input), "/");
+}
+//----------------------------------------------------------
+std::string ChainHelper::sampleName(const std::string &input, bool verbose)
+{
+    string sampleName;
+    bool fileFound(false), containerFound(false);
+    string fileName = ChainHelper::firstFile(input, verbose);
+    string containerName = "outputContainerName"; // see SusyNtMaker::writeMetaData()
+    if(TFile *inputFile = TFile::Open(fileName.c_str())) {
+        fileFound = true;
+        if(TKey *container = inputFile->FindKey(containerName.c_str())) {
+            containerFound = true;
+            sampleName = container->GetTitle();
+        }
+        inputFile->Close();
+        inputFile->Delete();
+    }
+    if(verbose && !containerFound) {
+        cout<<"ChainHelper::sampleName: failed."<<endl
+            <<" fileFound: "<<fileFound<<" (firstFile '"<<fileName<<"')"<<endl
+            <<" containerFound "<<containerFound<<" (containerName '"<<containerName<<"')"<<endl;
+    }
+    return sampleName;
 }
 //----------------------------------------------------------

--- a/Root/ChainHelper.cxx
+++ b/Root/ChainHelper.cxx
@@ -116,13 +116,24 @@ bool ChainHelper::inputIsDir(const std::string &input)
 //----------------------------------------------------------
 std::string ChainHelper::sampleName(const std::string &input, bool verbose)
 {
+    string containerName = "outputContainerName"; // see SusyNtMaker::writeMetaData()
+    return ChainHelper::readMetadataTitle(input, containerName, verbose);
+}
+//----------------------------------------------------------
+std::string ChainHelper::parentSampleName(const std::string &input, bool verbose)
+{
+    string containerName = "inputContainerName";
+    return ChainHelper::readMetadataTitle(input, containerName, verbose);
+}
+//----------------------------------------------------------
+std::string ChainHelper::readMetadataTitle(const std::string &input, const std::string tobjectName, bool verbose)
+{
     string sampleName;
     bool fileFound(false), containerFound(false);
     string fileName = ChainHelper::firstFile(input, verbose);
-    string containerName = "outputContainerName"; // see SusyNtMaker::writeMetaData()
     if(TFile *inputFile = TFile::Open(fileName.c_str())) {
         fileFound = true;
-        if(TKey *container = inputFile->FindKey(containerName.c_str())) {
+        if(TKey *container = inputFile->FindKey(tobjectName.c_str())) {
             containerFound = true;
             sampleName = container->GetTitle();
         }
@@ -132,7 +143,7 @@ std::string ChainHelper::sampleName(const std::string &input, bool verbose)
     if(verbose && !containerFound) {
         cout<<"ChainHelper::sampleName: failed."<<endl
             <<" fileFound: "<<fileFound<<" (firstFile '"<<fileName<<"')"<<endl
-            <<" containerFound "<<containerFound<<" (containerName '"<<containerName<<"')"<<endl;
+            <<" containerFound "<<containerFound<<" (TObject '"<<tobjectName<<"')"<<endl;
     }
     return sampleName;
 }

--- a/Root/SusyNtAna.cxx
+++ b/Root/SusyNtAna.cxx
@@ -316,7 +316,27 @@ int SusyNtAna::cleaningCutFlags()
   //                                  m_preMuons, m_baseMuons,
   //                                  m_preJets, m_baseJets);
 }
-
+//----------------------------------------------------------
+std::string SusyNtAna::sampleName() const
+{
+    if(m_sample.size()==0){
+        cout<<"SusyNtAna::sampleName: empty string."
+            <<" Did you forget to call setSampleName()?"
+            <<endl;
+    }
+    return m_sample;
+}
+//----------------------------------------------------------
+std::string SusyNtAna::parentSampleName() const
+{
+    if(m_parentSample.size()==0){
+        cout<<"SusyNtAna::parentSampleName: empty string."
+            <<" Did you forget to call setParentSampleName()?"
+            <<endl;
+    }
+    return m_parentSample;
+}
+//----------------------------------------------------------
 
 /*--------------------------------------------------------------------------------*/
 // Dump timer information

--- a/SusyNtuple/ChainHelper.h
+++ b/SusyNtuple/ChainHelper.h
@@ -53,8 +53,18 @@ class ChainHelper
     static bool inputIsList(const std::string &input);
     /// input directories are expected to end with '/'
     static bool inputIsDir(const std::string &input);
-    /// retrieve the sample name from the first root file
+    /// name of the sample being processed
+    /**
+       read from metadata from the first root file
+    */
     static std::string sampleName(const std::string &input, bool verbose);
+    /// name of the sample from which the ntuple was generated
+    /**
+       read from metadata from the first root file
+    */
+    static std::string parentSampleName(const std::string &input, bool verbose);
+ private:
+    static std::string readMetadataTitle(const std::string &input, const std::string tobjectName, bool verbose);
 };
 
 

--- a/SusyNtuple/ChainHelper.h
+++ b/SusyNtuple/ChainHelper.h
@@ -53,7 +53,8 @@ class ChainHelper
     static bool inputIsList(const std::string &input);
     /// input directories are expected to end with '/'
     static bool inputIsDir(const std::string &input);
-
+    /// retrieve the sample name from the first root file
+    static std::string sampleName(const std::string &input, bool verbose);
 };
 
 

--- a/SusyNtuple/SusyNtAna.h
+++ b/SusyNtuple/SusyNtAna.h
@@ -106,10 +106,15 @@ class SusyNtAna : public TSelector
     { checkAndAddRunEvent(runEventMap, run, event); }
 
     bool isDuplicate(unsigned int run, unsigned int event);
+    /// the sample name used to be used to guess metadata info
+    /**
+       You should set it to the value provided by
+       ChainHelper::sampleName(), unless you know what you're doing.
 
-    // Sample name - can be used however you like
-    std::string sampleName() const { return m_sample; }
+       DG-2015-09-18 Is this still being used anywhere to guess info?
+     */
     void setSampleName(std::string s) { m_sample = s; }
+    std::string sampleName() const { return m_sample; }
 
     /// getter to be used from outside (set xsec dir, access weight, etc.)
     MCWeighter& mcWeighter() { return m_mcWeighter; }

--- a/SusyNtuple/SusyNtAna.h
+++ b/SusyNtuple/SusyNtAna.h
@@ -106,15 +106,18 @@ class SusyNtAna : public TSelector
     { checkAndAddRunEvent(runEventMap, run, event); }
 
     bool isDuplicate(unsigned int run, unsigned int event);
-    /// the sample name used to be used to guess metadata info
+    /// the sample name, which used to be used to guess metadata info
     /**
        You should set it to the value provided by
        ChainHelper::sampleName(), unless you know what you're doing.
 
        DG-2015-09-18 Is this still being used anywhere to guess info?
      */
-    void setSampleName(std::string s) { m_sample = s; }
-    std::string sampleName() const { return m_sample; }
+    SusyNtAna& setSampleName(std::string s) { m_sample = s; return *this; }
+    std::string sampleName() const;
+    /// right now used only in Superflow to autoguess settings
+    SusyNtAna& setParentSampleName(std::string s) { m_parentSample = s; return *this; }
+    std::string parentSampleName() const;
 
     /// getter to be used from outside (set xsec dir, access weight, etc.)
     MCWeighter& mcWeighter() { return m_mcWeighter; }
@@ -146,6 +149,7 @@ class SusyNtAna : public TSelector
     bool  m_duplicate;          ///< duplicate event
     
     std::string m_sample;       ///< sample name string
+    std::string m_parentSample; ///< name of sample from which the ntuple was generated
 
     // To debug events in input file 
     RunEventMap m_eventList;          ///< run:event to debug 

--- a/util/Susy2LepCF.cxx
+++ b/util/Susy2LepCF.cxx
@@ -76,6 +76,7 @@ int main(int argc, char** argv)
   cout << "  input   " << input    << endl;
   cout << endl;
 
+  bool verbose = dbg>0;
   // Build the input chain
   TChain* chain = new TChain("susyNt");
   ChainHelper::addInput(chain, input, dbg>0);
@@ -85,7 +86,7 @@ int main(int argc, char** argv)
   // Build the TSelector
   Susy2LepCutflow* susyAna = new Susy2LepCutflow();
   susyAna->setDebug(dbg);
-  susyAna->setSampleName(sample);
+  susyAna->setSampleName(ChainHelper::sampleName(input, verbose));
   susyAna->setChain(chain); // propagate the TChain to the analysis
   susyAna->nttools().initTriggerTool(ChainHelper::firstFile(input, dbg>0));
   // Run the job

--- a/util/Susy3LepCF.cxx
+++ b/util/Susy3LepCF.cxx
@@ -85,6 +85,7 @@ int main(int argc, char** argv)
   cout << "  input   " << input    << endl;
   cout << endl;
 
+  bool verbose = dbg>0;
   // Build the input chain
   TChain* chain = new TChain("susyNt");
   ChainHelper::addInput(chain, input, dbg>0);
@@ -94,7 +95,7 @@ int main(int argc, char** argv)
   // Build the TSelector
   Susy3LepCutflow* susyAna = new Susy3LepCutflow();
   susyAna->setDebug(dbg);
-  susyAna->setSampleName(sample);
+  susyAna->setSampleName(ChainHelper::sampleName(input, verbose));
   susyAna->setSelection(sel);
   susyAna->nttools().initTriggerTool(ChainHelper::firstFile(input, dbg>0));
 

--- a/util/test_EventlistHandler.cxx
+++ b/util/test_EventlistHandler.cxx
@@ -95,7 +95,7 @@ int main(int argc, char **argv)
 
   DileptonCutflowWithList analysis;
   if(verbose) analysis.setDebug(1);
-  analysis.setSampleName(sampleName);
+  analysis.setSampleName(ChainHelper::sampleName(inputRootFname, verbose));
   analysis.m_eventList.setListName(sampleName); // can be anything; used to save the TEventList in the file
   analysis.m_eventList.setCacheFilename("./cache/"+sampleName+"_list.root"); // can be any (root) path where you have r/w permission
 


### PR DESCRIPTION
This info is now part of the metadata (`outputContainerName`).
Get it from the root file instead than expecting the user to provide it.
This could be implemented in `ChainHelper`, for example, so that
we can check we're not mixing different samples (or data with MC).
Allow the user to override this default behaviour via
`SusyNtAna::setSampleName()`