### PR TITLE
Adding4 l ana

### DIFF
--- a/Root/AnalysisType.cxx
+++ b/Root/AnalysisType.cxx
@@ -9,6 +9,7 @@ std::string AnalysisType2str(const AnalysisType &a)
     switch(a) {
     case AnalysisType::Ana_2Lep   : out = "Ana_2Lep"     ; break;
     case AnalysisType::Ana_3Lep   : out = "Ana_3Lep"     ; break;
+    case AnalysisType::Ana_4Lep   : out = "Ana_4Lep"     ; break;
     case AnalysisType::Ana_2LepWH : out = "Ana_2LepWH"   ; break;
     case AnalysisType::Ana_SS3L   : out = "Ana_SS3L"     ; break;
     case AnalysisType::Ana_Stop2L : out = "Ana_Stop2L"   ; break;

--- a/Root/ElectronSelector.cxx
+++ b/Root/ElectronSelector.cxx
@@ -28,6 +28,11 @@ ElectronSelector* ElectronSelector::build(const AnalysisType &a, bool verbose)
         s->setSignalId(ElectronId::TightLH);
         s->setSignalIsolation(Isolation::GradientLoose);
         break;
+    case AnalysisType::Ana_4Lep:
+        s = new ElectronSelector_4Lep();
+        s->setSignalId(ElectronId::MediumLH);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
     case AnalysisType::Ana_2LepWH:
         s = new ElectronSelector_2LepWH();
         s->setSignalId(ElectronId::TightLH);

--- a/Root/JetSelector.cxx
+++ b/Root/JetSelector.cxx
@@ -19,6 +19,7 @@ JetSelector* JetSelector::build(const AnalysisType &a, bool verbose)
     switch(a) {
     case AnalysisType::Ana_2Lep   : selector = new JetSelector_2Lep(); break;
     case AnalysisType::Ana_3Lep   : selector = new JetSelector_3Lep(); break;
+    case AnalysisType::Ana_4Lep   : selector = new JetSelector_4Lep(); break;
     case AnalysisType::Ana_2LepWH : selector = new JetSelector_2LepWH(); break;
     case AnalysisType::Ana_SS3L   : selector = new JetSelector_SS3L(); break;
     case AnalysisType::Ana_Stop2L : selector = new JetSelector_Stop2L(); break;
@@ -139,6 +140,13 @@ size_t JetSelector::count_F_jets(const JetVector &jets)
 // begin JetSelector_3Lep
 //----------------------------------------------------------
 
+//----------------------------------------------------------
+// begin JetSelector_4Lep
+//----------------------------------------------------------
+bool JetSelector_4Lep::isBaseline(const Jet* jet)
+{
+  return (jet->Pt() > 20.0);
+}
 //----------------------------------------------------------
 // begin JetSelector_2LepWH
 //----------------------------------------------------------

--- a/Root/MuonSelector.cxx
+++ b/Root/MuonSelector.cxx
@@ -26,6 +26,11 @@ MuonSelector* MuonSelector::build(const AnalysisType &a, bool verbose)
         s->setSignalId(MuonId::Medium);
         s->setSignalIsolation(Isolation::Tight);
         break;
+    case AnalysisType::Ana_4Lep   :
+        s = new MuonSelector_4Lep();
+        s->setSignalId(MuonId::Medium);
+        s->setSignalIsolation(Isolation::GradientLoose);
+        break;
     case AnalysisType::Ana_2LepWH :
         s = new MuonSelector_2LepWH();
         s->setSignalId(MuonId::Medium);
@@ -126,6 +131,20 @@ bool MuonSelector_3Lep::isSignal(const Muon* mu)
         pass = (isBaseline(mu) &&
                 mu->isoTight &&
                 passIpCut(mu));
+    }
+    return pass;
+}
+
+//----------------------------------------------------------
+// begin MuonSelector_4Lep
+//----------------------------------------------------------
+bool MuonSelector_4Lep::isBaseline(const Muon* mu)
+{    
+    bool pass = false;
+    if(mu) {
+        pass = (mu->medium &&
+                mu->Pt()        > 10.0 &&
+                fabs(mu->Eta()) <  2.5 );
     }
     return pass;
 }

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -77,6 +77,9 @@ OverlapTools* OverlapTools::build(const AnalysisType &a, bool verbose)
     case AnalysisType::Ana_3Lep   :
         o = new OverlapTools_3Lep();
         break;
+    case AnalysisType::Ana_4Lep   :
+        o = new OverlapTools_4Lep();
+        break;
     case AnalysisType::Ana_2LepWH :
         o = new OverlapTools_2LepWH();
         break;
@@ -373,6 +376,326 @@ void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets, double dR)
         } // for(iTau)
     } // for(iJet)
 }
+
+
+//----------------------------------------------------------
+// begin OverlapTools_4Lep
+//----------------------------------------------------------
+OverlapTools_4Lep::OverlapTools_4Lep():
+    OverlapTools(),
+    m_jetSelector(nullptr){}
+//----------------------------------------------------------
+void OverlapTools_4Lep::performOverlap(ElectronVector& electrons, MuonVector& muons,
+                                    TauVector& taus, JetVector& jets)
+{
+						///without the Photon OR
+                                                /// updated for SUSYTools/harmonization consistency Feb/16
+  /*1*/	t_e_overlap(taus,electrons,0.2); // straightforward dR comparison
+  /*2*/	t_m_overlap(taus, muons,0.2);    // dR comparison for taus pT<50. For tau pT>50, only compare to combined muons
+  /*3*/ e_m_overlap(electrons,muons);    // discard electrons sharing ID track with muons (Calo muons are be removed first if they share a track with an electron)
+  ///*4,5*/ photon_lep_overlap(photons, electrons, muons, 0.4);	// discard pho overlapping with e/mu
+  /*6*/	j_e_overlap(electrons, jets, 0.2);  // discard non-b-tagged jets with dR<0.2
+        e_j_overlap(electrons,jets,0.4);    // discard ele with dR<0.4 to non-pileup jets
+
+  /*7*/	j_m_overlap(muons, jets,0.2);  // discard jets with few tracks or small jet/mu pT ratio. 
+        m_j_overlap(muons, jets,0.4);       // discard ele with dR<0.4 to non-pileup jets
+  
+  /*8*/	j_t_overlap(taus,jets,0.2);  // discard jets overlapping with signal taus
+
+	///*9*/ j_photon_overlap(photons, jets, 0.4);	// discard jet overlapping with photon
+
+	//DY is performed in  'm_nttools.removeSFOSPairs' step
+	
+}
+void OverlapTools_4Lep::performOverlap(ElectronVector& electrons, MuonVector& muons,
+				       TauVector& taus,TauVector& SIGNALtaus, JetVector& jets, PhotonVector& photons, bool m_TauCtrlReg)
+{
+						///with the Photon OR
+						/// and Signal Taus for the last step
+                                                /// updated for SUSYTools/harmonization consistency Feb/16
+  /*1*/	t_e_overlap(taus,electrons,0.2); // straightforward dR comparison
+  /*2*/	t_m_overlap(taus, muons,0.2);    // dR comparison for taus pT<50. For tau pT>50, only compare to combined muons
+  /*3*/ e_m_overlap(electrons,muons);    // discard electrons sharing ID track with muons (Calo muons are be removed first if they share a track with an electron)
+  /*4,5*/ photon_lep_overlap(photons, electrons, muons, 0.4);	// discard pho overlapping with e/mu
+  /*6*/	j_e_overlap(electrons, jets, 0.2);  // discard non-b-tagged jets with dR<0.2
+        e_j_overlap(electrons,jets,0.4);    // discard ele with dR<0.4 to non-pileup jets
+
+  /*7*/	j_m_overlap(muons, jets,0.2);  // discard jets with few tracks or small jet/mu pT ratio. 
+        m_j_overlap(muons, jets,0.4);       // discard ele with dR<0.4 to non-pileup jets
+  
+  /*8*/	if(!m_TauCtrlReg) j_t_overlap(SIGNALtaus,jets,0.2);  // discard jets overlapping with signal taus
+	else j_t_overlap(taus,jets,0.2);  // compare to all loose taus for CR
+
+  /*9*/ j_photon_overlap(photons, jets, 0.4);	// discard jet overlapping with photon
+
+	//DY is performed in  'm_nttools.removeSFOSPairs' step
+	
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::e_m_overlap(ElectronVector& electrons, MuonVector& muons)
+{			
+  if(electrons.size()==0 || muons.size()==0) return;
+			
+  bool removeCaloMuons=true;
+  if(m_useOldOverlap) removeCaloMuons=false;
+  
+  // Discard Calo muons if they share a track with an electron
+  if( removeCaloMuons ){
+    for(int iMu=muons.size()-1; iMu>=0; iMu--){
+      const Muon* mu = muons.at(iMu);
+      if(mu->isCombined) continue;//if(!mu->isCalo) continue; // ATTENTION
+      for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
+	const Electron* e = electrons.at(iEl);
+	
+	// compare the tracks and dR to make sure it is overlapping THIS muon track
+	if( e->isMuon && e->DeltaRy(*mu) < 0.001){
+	  muons.erase(muons.begin()+iMu);
+	  break; 
+	}
+      } // iEl
+    } // iMu
+  } // if removeCaloMuons
+  
+  // discard electrons sharing ID track with surviving muons
+  for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
+    const Electron* e = electrons.at(iEl);
+    for(int iMu=muons.size()-1; iMu>=0; iMu--){
+      const Muon* mu = muons.at(iMu);
+      
+      if (e->isMuon && e->DeltaRy(*mu) < 0.001){
+	electrons.erase(electrons.begin()+iEl);
+	break; 
+      }
+    } // iEl
+  } // iMu
+    
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::t_m_overlap(TauVector& taus, MuonVector& muons, double dR)
+{
+  if(taus.size()==0 || muons.size()==0) return;
+
+  for(int iTau=taus.size()-1; iTau>=0; iTau--){
+    const Tau* tau = taus.at(iTau);
+    for(int iMu=muons.size()-1; iMu>=0; iMu--){
+      const Muon* mu = muons.at(iMu);
+      //High-pT taus are only compared to combined muons
+      if(tau->Pt()>50.0 && !mu->isCombined) continue; 
+
+      if(tau->DeltaRy(*mu) < dR){
+	taus.erase(taus.begin()+iTau);
+	break; 
+      } // if(dR< )
+
+    } // for(iMu)
+  } // for(iTau)
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::photon_lep_overlap(PhotonVector& photons, ElectronVector& /*pre*/electrons, MuonVector& /*pre*/muons, double dR)
+{	
+  if( photons.size()==0) return;
+
+  // discard photons overlapping with muons
+  for(int iPho=photons.size()-1; iPho>=0; iPho--){
+    const Photon* pho = photons.at(iPho);
+    for(int iMu=muons.size()-1; iMu>=0; iMu--){
+      const Muon* mu = muons.at(iMu);
+
+      if(pho->DeltaRy(*mu) < dR){
+	photons.erase(photons.begin()+iPho);
+	break; 
+      } // if(dR< )
+
+    } // for(iMu)
+  } // for(iPho)
+
+  // discard photons overlapping with electrons
+  for(int iPho=photons.size()-1; iPho>=0; iPho--){
+    const Photon* pho = photons.at(iPho);
+    for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
+      const Electron* el = electrons.at(iEl);
+
+      if(pho->DeltaRy(*el) < dR){
+	photons.erase(photons.begin()+iPho);
+	break; 
+      } // if(dR< )
+
+    } // for(iEl)
+  } // for(iPho)
+
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR)
+{
+  if(electrons.size()==0 || jets.size()==0) return;
+
+  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
+  if(not jetSelector) {
+    cerr<<"OverlapTools_4Lep: cannot perform j_e_overlap without JetSelector"<<endl
+	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
+    // assert(false);
+  }
+
+  for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
+    const Electron* e = electrons.at(iEl);
+    for(int iJ=jets.size()-1; iJ>=0; iJ--){
+      const Jet* j = jets.at(iJ);
+
+      bool is_bjet = m_jetSelector->isB(j);
+      // only compare non-b-tagged jets
+      if( is_bjet ) continue;
+
+      if(e->DeltaRy(*j) < dR) {
+	if(verbose()) print_rm_msg("j_e_overlap: ", j, e);
+	jets.erase(jets.begin()+iJ);
+      }
+
+    } // iJ
+  } // iEl
+
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR)
+{
+  if(electrons.size()==0 || jets.size()==0) return;
+
+  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
+  if(not jetSelector) {
+    cerr<<"OverlapTools_4Lep: cannot perform e_j_overlap without JetSelector"<<endl
+	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
+    // assert(false);
+  }
+
+  for(int iEl=electrons.size()-1; iEl>=0; iEl--){
+    const Electron* e = electrons.at(iEl);
+    for(size_t iJ=0; iJ<jets.size(); iJ++){
+      const Jet* j = jets.at(iJ);
+      
+      bool pass_jvt = m_jetSelector->passJvt(j);
+      //don't compare with pileup jets
+      if( !m_useOldOverlap && !pass_jvt ) continue;
+      
+      if(e->DeltaRy(*j) < dR) {
+	if(verbose()) print_rm_msg("e_j_overlap: ", e, j);
+	electrons.erase(electrons.begin()+iEl);
+	break;
+      }
+      
+    } // for(iJ)
+  } // for(iEl)
+
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::j_m_overlap(MuonVector& muons, JetVector& jets, double dR)
+{
+  if(muons.size()==0 || jets.size()==0) return;
+
+  bool useGhostAssoc=true;
+  if(m_useOldOverlap) useGhostAssoc=false;
+
+  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
+  if(not jetSelector) {
+    cerr<<"OverlapTools_4Lep: cannot perform j_m_overlap without JetSelector"<<endl
+	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
+    // assert(false);
+  }
+
+  for(int iMu=muons.size()-1; iMu>=0; iMu--) {
+    const Muon* mu = muons.at(iMu);
+    for(int iJ=jets.size()-1; iJ>=0; iJ--){
+      const Jet* j = jets.at(iJ);
+
+      bool is_bjet = m_jetSelector->isB(j);
+      // only compare non-b-tagged jets
+      if( is_bjet ) continue;
+
+      bool discard_jet = false;
+      if(useGhostAssoc){
+	if(mu->DeltaRy(*j) < 0.2) discard_jet = true;
+	//if( mu->isGhostTrack && mu->DeltaRy(*j) < 0.4 ) discard_jet = true; // ATTENTION
+      }
+      else{
+	if( m_useOldOverlap ) continue;
+	int jet_nTrk = j->nTracks;
+	double sumTrkPt = mu->Pt(); // need jet getSumTrackPt(*jet, vtx->index()); ATTENTION
+	if( jet_nTrk >= 3  && (mu->Pt()/j->Pt() < 0.5 || mu->Pt()/sumTrkPt < 0.7)) continue;
+	if(mu->DeltaRy(*j) < 0.2) discard_jet = true;
+      }
+
+      if(discard_jet) {
+	if(verbose()) print_rm_msg("j_m_overlap: ", j, mu);
+	jets.erase(jets.begin()+iJ);
+      }
+
+    } // iJ
+  } // iMu
+
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::m_j_overlap(MuonVector& muons, JetVector& jets, double dR)
+{
+  if(muons.size()==0 || jets.size()==0) return;
+
+  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
+  if(not jetSelector) {
+    cerr<<"OverlapTools_4Lep: cannot perform m_j_overlap without JetSelector"<<endl
+	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
+    // assert(false);
+  }
+
+  for(int iMu=muons.size()-1; iMu>=0; iMu--){
+    const Muon* mu = muons.at(iMu);
+    for(size_t iJ=0; iJ<jets.size(); iJ++){
+      const Jet* j = jets.at(iJ);
+      
+      bool pass_jvt = m_jetSelector->passJvt(j);
+      //don't compare with pileup jets
+      if( !m_useOldOverlap && !pass_jvt ) continue;
+      
+      if(mu->DeltaRy(*j) < dR) {
+	if(verbose()) print_rm_msg("m_j_overlap: ", mu, j);
+	muons.erase(muons.begin()+iMu);
+	break;
+      }
+      
+    } // for(iJ)
+  } // for(iMu)
+}
+
+//----------------------------------------------------------
+void OverlapTools_4Lep::j_photon_overlap(PhotonVector& photons, JetVector& jets, double dR)
+{
+
+  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
+  if(not jetSelector) {
+    cerr<<"OverlapTools_4Lep: cannot perform j_photon_overlap without JetSelector"<<endl
+	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
+    // assert(false);
+  }
+
+  if(photons.size()==0 || jets.size()==0) return;
+  for(int iPh=photons.size()-1; iPh>=0; iPh--) {
+    const Photon* ph = photons.at(iPh);
+
+    for(int iJ=jets.size()-1; iJ>=0; iJ--){
+      const Jet* j = jets.at(iJ);
+
+      if(ph->DeltaRy(*j) < dR) {
+	jets.erase(jets.begin()+iJ);
+      }
+
+    } // iJ
+  } // iPh
+
+}
+
 //----------------------------------------------------------
 // begin OverlapTools_SS3L
 //----------------------------------------------------------

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -381,10 +381,6 @@ void OverlapTools::j_t_overlap(TauVector& taus, JetVector& jets, double dR)
 //----------------------------------------------------------
 // begin OverlapTools_4Lep
 //----------------------------------------------------------
-OverlapTools_4Lep::OverlapTools_4Lep():
-    OverlapTools(),
-    m_jetSelector(nullptr){}
-//----------------------------------------------------------
 void OverlapTools_4Lep::performOverlap(ElectronVector& electrons, MuonVector& muons,
                                     TauVector& taus, JetVector& jets)
 {
@@ -533,13 +529,6 @@ void OverlapTools_4Lep::j_e_overlap(ElectronVector& electrons, JetVector& jets, 
 {
   if(electrons.size()==0 || jets.size()==0) return;
 
-  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
-  if(not jetSelector) {
-    cerr<<"OverlapTools_4Lep: cannot perform j_e_overlap without JetSelector"<<endl
-	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
-    // assert(false);
-  }
-
   for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
     const Electron* e = electrons.at(iEl);
     for(int iJ=jets.size()-1; iJ>=0; iJ--){
@@ -563,13 +552,6 @@ void OverlapTools_4Lep::j_e_overlap(ElectronVector& electrons, JetVector& jets, 
 void OverlapTools_4Lep::e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR)
 {
   if(electrons.size()==0 || jets.size()==0) return;
-
-  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
-  if(not jetSelector) {
-    cerr<<"OverlapTools_4Lep: cannot perform e_j_overlap without JetSelector"<<endl
-	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
-    // assert(false);
-  }
 
   for(int iEl=electrons.size()-1; iEl>=0; iEl--){
     const Electron* e = electrons.at(iEl);
@@ -598,13 +580,6 @@ void OverlapTools_4Lep::j_m_overlap(MuonVector& muons, JetVector& jets, double d
 
   bool useGhostAssoc=true;
   if(m_useOldOverlap) useGhostAssoc=false;
-
-  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
-  if(not jetSelector) {
-    cerr<<"OverlapTools_4Lep: cannot perform j_m_overlap without JetSelector"<<endl
-	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
-    // assert(false);
-  }
 
   for(int iMu=muons.size()-1; iMu>=0; iMu--) {
     const Muon* mu = muons.at(iMu);
@@ -643,13 +618,6 @@ void OverlapTools_4Lep::m_j_overlap(MuonVector& muons, JetVector& jets, double d
 {
   if(muons.size()==0 || jets.size()==0) return;
 
-  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
-  if(not jetSelector) {
-    cerr<<"OverlapTools_4Lep: cannot perform m_j_overlap without JetSelector"<<endl
-	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
-    // assert(false);
-  }
-
   for(int iMu=muons.size()-1; iMu>=0; iMu--){
     const Muon* mu = muons.at(iMu);
     for(size_t iJ=0; iJ<jets.size(); iJ++){
@@ -672,13 +640,6 @@ void OverlapTools_4Lep::m_j_overlap(MuonVector& muons, JetVector& jets, double d
 //----------------------------------------------------------
 void OverlapTools_4Lep::j_photon_overlap(PhotonVector& photons, JetVector& jets, double dR)
 {
-
-  JetSelector_4Lep* jetSelector = static_cast<JetSelector_4Lep*>(m_jetSelector);
-  if(not jetSelector) {
-    cerr<<"OverlapTools_4Lep: cannot perform j_photon_overlap without JetSelector"<<endl
-	<<"Please call OverlapTools_4Lep::jetSelector(JetSelector*)"<<endl;
-    // assert(false);
-  }
 
   if(photons.size()==0 || jets.size()==0) return;
   for(int iPh=photons.size()-1; iPh>=0; iPh--) {

--- a/Root/OverlapTools.cxx
+++ b/Root/OverlapTools.cxx
@@ -164,6 +164,15 @@ void OverlapTools::removeNonisolatedLeptons(ElectronVector& electrons, MuonVecto
     }
 }
 //----------------------------------------------------------
+bool OverlapTools::muonIsGhostMatched(const Muon* mu, const Jet* jet)
+{
+  if(!(mu->ghostTrack.size()>0))
+    return false;
+  if(jet->idx > ((int)mu->ghostTrack.size()-1))
+    return false;
+  return ((mu->ghostTrack[jet->idx]==1) ? true : false); 
+}
+//----------------------------------------------------------
 void OverlapTools::j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR)
 {
     // default procedure:
@@ -440,7 +449,7 @@ void OverlapTools_4Lep::e_m_overlap(ElectronVector& electrons, MuonVector& muons
   if( removeCaloMuons ){
     for(int iMu=muons.size()-1; iMu>=0; iMu--){
       const Muon* mu = muons.at(iMu);
-      if(mu->isCombined) continue;//if(!mu->isCalo) continue; // ATTENTION
+      if(!mu->isCaloTagged) continue; 
       for(int iEl=electrons.size()-1; iEl>=0; iEl--) {
 	const Electron* e = electrons.at(iEl);
 	
@@ -593,12 +602,12 @@ void OverlapTools_4Lep::j_m_overlap(MuonVector& muons, JetVector& jets, double d
       bool discard_jet = false;
       if(useGhostAssoc){
 	if(mu->DeltaRy(*j) < 0.2) discard_jet = true;
-	//if( mu->isGhostTrack && mu->DeltaRy(*j) < 0.4 ) discard_jet = true; // ATTENTION
+	if(muonIsGhostMatched(mu, j) ) discard_jet=true;
       }
       else{
 	if( m_useOldOverlap ) continue;
 	int jet_nTrk = j->nTracks;
-	double sumTrkPt = mu->Pt(); // need jet getSumTrackPt(*jet, vtx->index()); ATTENTION
+	double sumTrkPt = j->sumTrkPt;
 	if( jet_nTrk >= 3  && (mu->Pt()/j->Pt() < 0.5 || mu->Pt()/sumTrkPt < 0.7)) continue;
 	if(mu->DeltaRy(*j) < 0.2) discard_jet = true;
       }

--- a/Root/PhotonSelector.cxx
+++ b/Root/PhotonSelector.cxx
@@ -24,6 +24,7 @@ PhotonSelector::PhotonSelector() :
     m_sigIso(Isolation::IsolationInvalid),
     m_2lep(false),
     m_3lep(false),
+    m_4lep(false),
     m_2lepWH(false),
     m_SS3L(false),
     m_verbose(false)
@@ -49,6 +50,13 @@ PhotonSelector& PhotonSelector::setAnalysis(const AnalysisType &a)
     //////////////////////////////////////
     else if ( a == AnalysisType::Ana_3Lep ) {
         m_3lep = true;
+        m_sigIso = Isolation::FixedCutTight;
+    }
+    //////////////////////////////////////
+    // 4L-Analysis
+    //////////////////////////////////////
+    else if ( a == AnalysisType::Ana_4Lep ) {
+        m_4lep = true;
         m_sigIso = Isolation::FixedCutTight;
     }
     //////////////////////////////////////

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -59,6 +59,7 @@ void SusyNtTools::setAnaType(AnalysisType a, bool verbose)
     // propagate isolation requirements, needed only for removeNonisolatedLeptons()
     m_overlapTool->setElectronIsolation(electronSelector().signalIsolation());
     m_overlapTool->setMuonIsolation(muonSelector().signalIsolation());
+    m_overlapTool->jetSelector(m_jetSelector);
 
     // set whether to perform SFOS removal on baseline objects
     setSFOSRemoval(a);

--- a/Root/SusyNtTools.cxx
+++ b/Root/SusyNtTools.cxx
@@ -131,6 +131,7 @@ void SusyNtTools::setSFOSRemoval(AnalysisType a)
 {
     if(a == AnalysisType::Ana_2Lep ||
        a == AnalysisType::Ana_3Lep ||
+       a == AnalysisType::Ana_4Lep ||
        a == AnalysisType::Ana_2LepWH ) { m_doSFOS = true; }
 
     else if( a == AnalysisType::Ana_SS3L )   { m_doSFOS = false; }

--- a/Root/TauSelector.cxx
+++ b/Root/TauSelector.cxx
@@ -17,6 +17,7 @@ TauSelector* TauSelector::build(const AnalysisType &a, bool verbose)
     switch(a) {
     case AnalysisType::Ana_2Lep   : selector = new TauSelector_2Lep(); break;
     case AnalysisType::Ana_3Lep   : selector = new TauSelector_3Lep(); break;
+    case AnalysisType::Ana_4Lep   : selector = new TauSelector_4Lep(); break;
     case AnalysisType::Ana_2LepWH : selector = new TauSelector_2LepWH(); break;
     case AnalysisType::Ana_SS3L   : selector = new TauSelector_SS3L(); break;
     case AnalysisType::Ana_Stop2L : selector = new TauSelector_Stop2L(); break;
@@ -72,6 +73,18 @@ bool TauSelector::passBdtSignal(const Tau& tau)
 //----------------------------------------------------------
 // begin JetSelector_3Lep
 //----------------------------------------------------------
+
+//----------------------------------------------------------
+// begin TauSelector_4Lep
+//----------------------------------------------------------
+bool TauSelector_4Lep::isBaseline(const Tau& tau)
+{
+    return (tau.Pt() > 20.0 					&&
+			std::abs(tau.Eta()) < 2.47			&& 
+			(tau.nTrack == 1 || tau.nTrack ==3 )&&
+			std::abs(tau.q) == 1 				&&
+            passBdtBaseline(tau));
+}
 
 //----------------------------------------------------------
 // begin JetSelector_2LepWH

--- a/SusyNtuple/AnalysisType.h
+++ b/SusyNtuple/AnalysisType.h
@@ -10,6 +10,7 @@ namespace Susy
 enum class AnalysisType {
     Ana_2Lep,       ///< Dilepton electroweak
     Ana_3Lep,       ///< trilepton electroweak
+    Ana_4Lep,       ///< 4L electroweak/RPV
     Ana_2LepWH,     ///< C1N2 in WH samesign+jets
     Ana_SS3L,       ///< Strong SS3L analysis 
     Ana_Stop2L,     ///< Direct stop to two lepton analysis

--- a/SusyNtuple/ElectronSelector.h
+++ b/SusyNtuple/ElectronSelector.h
@@ -105,6 +105,11 @@ class ElectronSelector_3Lep : public ElectronSelector
 {
 };
 
+/// implements electron selection for 4L
+class ElectronSelector_4Lep : public ElectronSelector
+{
+};
+
 /// implements electron selection for ATL-COM-PHYS-2014-221
 class ElectronSelector_2LepWH : public ElectronSelector
 {

--- a/SusyNtuple/JetSelector.h
+++ b/SusyNtuple/JetSelector.h
@@ -126,6 +126,12 @@ class JetSelector_3Lep : public JetSelector
 {
 };
 
+/// implements jet selection for 4L
+class JetSelector_4Lep : public JetSelector
+{
+  bool isBaseline(const Jet* jet);
+};
+
 /// implements jet selection from ATL-COM-PHYS-2014-221
 class JetSelector_2LepWH : public JetSelector
 {

--- a/SusyNtuple/MuonSelector.h
+++ b/SusyNtuple/MuonSelector.h
@@ -98,6 +98,12 @@ class MuonSelector_3Lep : public MuonSelector
     virtual bool isSignal(const Muon* mu);
 };
 
+/// implements muon selection for 4L
+class MuonSelector_4Lep : public MuonSelector
+{
+    bool isBaseline(const Muon* mu);
+};
+
 /// implements muon selection for ATL-COM-PHYS-2014-221
 class MuonSelector_2LepWH : public MuonSelector
 {

--- a/SusyNtuple/OverlapTools.h
+++ b/SusyNtuple/OverlapTools.h
@@ -106,8 +106,7 @@ class OverlapTools_3Lep : public OverlapTools
 class OverlapTools_4Lep : public OverlapTools
 {
 public:
-  virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, JetVector& jets);
-  virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, TauVector& SIGNALtaus, JetVector& jets, PhotonVector& photons, bool m_TauCtrlReg);
+  virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, TauVector& LOOSEtaus, JetVector& jets, PhotonVector& photons, bool m_TauCtrlReg);
   virtual void e_m_overlap(ElectronVector& electrons, MuonVector& muons); ///< remove electron from muon
   virtual void t_m_overlap(TauVector& taus, MuonVector& muons, double dR); ///< remove tau from muon
   virtual void photon_lep_overlap(PhotonVector& photons, ElectronVector& electrons, MuonVector& muons, double dR);

--- a/SusyNtuple/OverlapTools.h
+++ b/SusyNtuple/OverlapTools.h
@@ -43,6 +43,8 @@ public :
     */
     virtual void performOverlap(ElectronVector& electrons, MuonVector& muons,
                                 TauVector& taus, JetVector& jets);
+    virtual void performOverlap(ElectronVector& electrons, MuonVector& muons,
+				TauVector& taus, TauVector& , JetVector& jets, PhotonVector& , bool, bool){performOverlap(electrons,muons,taus,jets);}
     virtual void j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR); ///< remove jet from electron
     virtual void e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR); ///< remove electron from jet
     virtual void m_j_overlap(MuonVector& muons, JetVector& jets, double dR); ///< remove muon from jet
@@ -70,11 +72,13 @@ public :
     /// used within removeNonisolatedLeptons()
     bool leptonPassesIsolation(const Lepton* lep, const Isolation &iso);
     OverlapTools& setVerbose(bool v) { m_verbose = v; return *this; }
+    OverlapTools& useOldOverlap(bool v) { m_useOldOverlap = v; return *this; }
     bool verbose() const { return m_verbose; }
 protected :
     Isolation m_electronIsolation;
     Isolation m_muonIsolation;
     bool m_verbose;
+    bool m_useOldOverlap;
 }; // class OverlapTools
 
 //----------------------------------------------------------
@@ -91,6 +95,30 @@ class OverlapTools_2Lep : public OverlapTools
 class OverlapTools_3Lep : public OverlapTools
 {
 };
+
+/// implements OR procedure for 4L
+class OverlapTools_4Lep : public OverlapTools
+{
+public:
+    OverlapTools_4Lep(); ///< Default ctor
+    virtual JetSelector* jetSelector() const { return m_jetSelector; }
+    virtual OverlapTools_4Lep& jetSelector(JetSelector* js) { m_jetSelector = js; return *this; }
+
+  virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, JetVector& jets);
+  virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, TauVector& SIGNALtaus, JetVector& jets, PhotonVector& photons, bool m_TauCtrlReg);
+  virtual void e_m_overlap(ElectronVector& electrons, MuonVector& muons); ///< remove electron from muon
+  virtual void t_m_overlap(TauVector& taus, MuonVector& muons, double dR); ///< remove tau from muon
+  virtual void photon_lep_overlap(PhotonVector& photons, ElectronVector& electrons, MuonVector& muons, double dR);
+  virtual void j_m_overlap(MuonVector& muons, JetVector& jets, double dR);
+  virtual void m_j_overlap(MuonVector& muons, JetVector& jets, double dR);
+  virtual void j_e_overlap(ElectronVector& electrons, JetVector& jets, double dR); ///< remove jet from electron
+  virtual void e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR); ///< remove electron from jet
+  virtual void j_photon_overlap(PhotonVector& photons, JetVector& jets, double dR);
+protected:
+  JetSelector* m_jetSelector;           ///< select jets according to the current analysis settings
+
+};
+
 
 /// implements OR procedure from ATL-COM-PHYS-2014-221
 class OverlapTools_2LepWH : public OverlapTools

--- a/SusyNtuple/OverlapTools.h
+++ b/SusyNtuple/OverlapTools.h
@@ -74,6 +74,8 @@ public :
     OverlapTools& jetSelector(JetSelector* js) { m_jetSelector = js; return *this; }
     /// used within removeNonisolatedLeptons()
     bool leptonPassesIsolation(const Lepton* lep, const Isolation &iso);
+    /// check if muon ID tracks are ghost associated with the input jet
+    bool muonIsGhostMatched(const Muon* mu, const Jet* jet);
     OverlapTools& setVerbose(bool v) { m_verbose = v; return *this; }
     OverlapTools& useOldOverlap(bool v) { m_useOldOverlap = v; return *this; }
     bool verbose() const { return m_verbose; }

--- a/SusyNtuple/OverlapTools.h
+++ b/SusyNtuple/OverlapTools.h
@@ -69,6 +69,9 @@ public :
     OverlapTools& setElectronIsolation( Isolation eleIso ) { m_electronIsolation = eleIso; return *this; }
     /// muon isolation used in leptonPassesIsolation()
     OverlapTools& setMuonIsolation( Isolation muIso ) { m_muonIsolation = muIso; return *this; }
+    /// jet selector needed for j_X OR
+    JetSelector* jetSelector() const { return m_jetSelector; }
+    OverlapTools& jetSelector(JetSelector* js) { m_jetSelector = js; return *this; }
     /// used within removeNonisolatedLeptons()
     bool leptonPassesIsolation(const Lepton* lep, const Isolation &iso);
     OverlapTools& setVerbose(bool v) { m_verbose = v; return *this; }
@@ -77,6 +80,7 @@ public :
 protected :
     Isolation m_electronIsolation;
     Isolation m_muonIsolation;
+    JetSelector *m_jetSelector;
     bool m_verbose;
     bool m_useOldOverlap;
 }; // class OverlapTools
@@ -100,10 +104,6 @@ class OverlapTools_3Lep : public OverlapTools
 class OverlapTools_4Lep : public OverlapTools
 {
 public:
-    OverlapTools_4Lep(); ///< Default ctor
-    virtual JetSelector* jetSelector() const { return m_jetSelector; }
-    virtual OverlapTools_4Lep& jetSelector(JetSelector* js) { m_jetSelector = js; return *this; }
-
   virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, JetVector& jets);
   virtual void performOverlap(ElectronVector& electrons, MuonVector& muons, TauVector& taus, TauVector& SIGNALtaus, JetVector& jets, PhotonVector& photons, bool m_TauCtrlReg);
   virtual void e_m_overlap(ElectronVector& electrons, MuonVector& muons); ///< remove electron from muon
@@ -115,7 +115,6 @@ public:
   virtual void e_j_overlap(ElectronVector& electrons, JetVector& jets, double dR); ///< remove electron from jet
   virtual void j_photon_overlap(PhotonVector& photons, JetVector& jets, double dR);
 protected:
-  JetSelector* m_jetSelector;           ///< select jets according to the current analysis settings
 
 };
 

--- a/SusyNtuple/PhotonSelector.h
+++ b/SusyNtuple/PhotonSelector.h
@@ -31,6 +31,7 @@ namespace Susy {
         ///////////////////////////////
         bool m_2lep;    ///< flag for 2L analysis
         bool m_3lep;    ///< flag for 3L analysis
+        bool m_4lep;    ///< flag for 3L analysis
         bool m_2lepWH;  ///< flag for 2L WH analysis
         bool m_SS3L;    ///< flag for the strong SS3L analysis 
 

--- a/SusyNtuple/TauSelector.h
+++ b/SusyNtuple/TauSelector.h
@@ -76,6 +76,12 @@ class TauSelector_3Lep : public TauSelector
 {
 };
 
+/// 4Leptons search
+class TauSelector_4Lep : public TauSelector
+{
+	bool isBaseline(const Tau& tau);
+};
+
 /// implements tau selection for ATL-COM-PHYS-2014-221
 class TauSelector_2LepWH : public TauSelector
 {


### PR DESCRIPTION
- Added 4Lep AnaType
- Added 4Lep specific overlap-removal functions. These follow the latest SUSYTools OR recommendations (i.e. those in the AssociationUtils OverlapRemovalTool) and could be made default for all analyses if needed.
- The jet-X OR functions now need access to the jetSelector class, as we only compare to non-pileup/b-tag jets. I've added this in as a property of the OverlapRemoval class so it can be used easily for all analyses.
It would be great if these changes could make it into n0221 please.